### PR TITLE
Only import enum34 on python versions < 3.4

### DIFF
--- a/requirements.docs.txt
+++ b/requirements.docs.txt
@@ -1,5 +1,5 @@
 future
 requests
-enum34
+enum34; python_version < '3.4'
 sphinx
 sphinx_rtd_theme

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 future
 requests
-enum34
+enum34; python_version < '3.4'

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setup(
     download_url=extract_metaitem('download_url'),
     packages=find_packages(exclude=('tests', 'docs')),
     platforms=['Any'],
-    install_requires=['future', 'requests', 'enum34'],
+    install_requires=['future', 'requests', 'enum34;python_version<"3.4"'],
     setup_requires=['pytest-runner'],
     tests_require=['pytest'],
     keywords='here api',


### PR DESCRIPTION
enum34 breaks python environments which are 3.6 or later.

With this PR it is only required when 3.4 or earlier is detected