### PR TITLE
Add 'route_short' as a description

### DIFF
--- a/herepy/here_enum.py
+++ b/herepy/here_enum.py
@@ -6,11 +6,13 @@ class RouteMode(Enum):
     """Modes which is used in routing api functions."""
 
     fastest = 'fastest'
+    bicycle = 'bicycle'
     car = 'car'
     traffic_disabled = 'traffic:disabled'
     enabled = 'enabled'
     pedestrian = 'pedestrian'
     publicTransport = 'publicTransport'
+    publicTransportTimeTable = 'publicTransportTimeTable'
     truck = 'truck'
     traffic_default = 'traffic:default'
 

--- a/herepy/models.py
+++ b/herepy/models.py
@@ -109,7 +109,8 @@ class RoutingResponse(HEREModel):
     def __init__(self, **kwargs):
         super(RoutingResponse, self).__init__()
         self.param_defaults = {
-            'response': None
+            'response': None,
+            'route_short': None
         }
 
         for (param, default) in self.param_defaults.items():

--- a/testdata/models/routing_bicycle.json
+++ b/testdata/models/routing_bicycle.json
@@ -1,0 +1,274 @@
+{
+    "response": {
+        "metaInfo": {
+            "timestamp": "2019-07-24T10:17:40Z",
+            "mapVersion": "8.30.98.154",
+            "moduleVersion": "7.2.201929-4522",
+            "interfaceVersion": "2.6.64",
+            "availableMapVersion": [
+                "8.30.98.154"
+            ]
+        },
+        "route": [
+            {
+                "waypoint": [
+                    {
+                        "linkId": "-1230414527",
+                        "mappedPosition": {
+                            "latitude": 41.9797859,
+                            "longitude": -87.8790879
+                        },
+                        "originalPosition": {
+                            "latitude": 41.9798,
+                            "longitude": -87.8801
+                        },
+                        "type": "stopOver",
+                        "spot": 0.5079365,
+                        "sideOfStreet": "right",
+                        "mappedRoadName": "Mannheim Rd",
+                        "label": "Mannheim Rd - US-12",
+                        "shapeIndex": 0,
+                        "source": "user"
+                    },
+                    {
+                        "linkId": "+924115108",
+                        "mappedPosition": {
+                            "latitude": 41.90413,
+                            "longitude": -87.9223502
+                        },
+                        "originalPosition": {
+                            "latitude": 41.9043,
+                            "longitude": -87.9216001
+                        },
+                        "type": "stopOver",
+                        "spot": 0.1925926,
+                        "sideOfStreet": "right",
+                        "mappedRoadName": "",
+                        "label": "",
+                        "shapeIndex": 87,
+                        "source": "user"
+                    }
+                ],
+                "mode": {
+                    "type": "fastest",
+                    "transportModes": [
+                        "bicycle"
+                    ],
+                    "trafficMode": "enabled",
+                    "feature": []
+                },
+                "leg": [
+                    {
+                        "start": {
+                            "linkId": "-1230414527",
+                            "mappedPosition": {
+                                "latitude": 41.9797859,
+                                "longitude": -87.8790879
+                            },
+                            "originalPosition": {
+                                "latitude": 41.9798,
+                                "longitude": -87.8801
+                            },
+                            "type": "stopOver",
+                            "spot": 0.5079365,
+                            "sideOfStreet": "right",
+                            "mappedRoadName": "Mannheim Rd",
+                            "label": "Mannheim Rd - US-12",
+                            "shapeIndex": 0,
+                            "source": "user"
+                        },
+                        "end": {
+                            "linkId": "+924115108",
+                            "mappedPosition": {
+                                "latitude": 41.90413,
+                                "longitude": -87.9223502
+                            },
+                            "originalPosition": {
+                                "latitude": 41.9043,
+                                "longitude": -87.9216001
+                            },
+                            "type": "stopOver",
+                            "spot": 0.1925926,
+                            "sideOfStreet": "right",
+                            "mappedRoadName": "",
+                            "label": "",
+                            "shapeIndex": 87,
+                            "source": "user"
+                        },
+                        "length": 12613,
+                        "travelTime": 3292,
+                        "maneuver": [
+                            {
+                                "position": {
+                                    "latitude": 41.9797859,
+                                    "longitude": -87.8790879
+                                },
+                                "instruction": "Head <span class=\"heading\">south</span> on <span class=\"street\">Mannheim Rd</span> <span class=\"number\">(US-12/US-45)</span>. <span class=\"distance-description\">Go for <span class=\"length\">2.6 km</span>.</span>",
+                                "travelTime": 646,
+                                "length": 2648,
+                                "id": "M1",
+                                "_type": "PrivateTransportManeuverType"
+                            },
+                            {
+                                "position": {
+                                    "latitude": 41.9579244,
+                                    "longitude": -87.8838551
+                                },
+                                "instruction": "Keep <span class=\"direction\">left</span> onto <span class=\"next-street\">Mannheim Rd</span> <span class=\"number\">(US-12/US-45)</span>. <span class=\"distance-description\">Go for <span class=\"length\">2.4 km</span>.</span>",
+                                "travelTime": 621,
+                                "length": 2427,
+                                "id": "M2",
+                                "_type": "PrivateTransportManeuverType"
+                            },
+                            {
+                                "position": {
+                                    "latitude": 41.9364238,
+                                    "longitude": -87.8849387
+                                },
+                                "instruction": "Turn <span class=\"direction\">right</span> onto <span class=\"next-street\">W Belmont Ave</span>. <span class=\"distance-description\">Go for <span class=\"length\">595 m</span>.</span>",
+                                "travelTime": 158,
+                                "length": 595,
+                                "id": "M3",
+                                "_type": "PrivateTransportManeuverType"
+                            },
+                            {
+                                "position": {
+                                    "latitude": 41.9362521,
+                                    "longitude": -87.8921163
+                                },
+                                "instruction": "Turn <span class=\"direction\">left</span> onto <span class=\"next-street\">Cullerton St</span>. <span class=\"distance-description\">Go for <span class=\"length\">669 m</span>.</span>",
+                                "travelTime": 180,
+                                "length": 669,
+                                "id": "M4",
+                                "_type": "PrivateTransportManeuverType"
+                            },
+                            {
+                                "position": {
+                                    "latitude": 41.9305658,
+                                    "longitude": -87.8932428
+                                },
+                                "instruction": "Continue on <span class=\"next-street\">N Landen Dr</span>. <span class=\"distance-description\">Go for <span class=\"length\">976 m</span>.</span>",
+                                "travelTime": 246,
+                                "length": 976,
+                                "id": "M5",
+                                "_type": "PrivateTransportManeuverType"
+                            },
+                            {
+                                "position": {
+                                    "latitude": 41.9217896,
+                                    "longitude": -87.8928781
+                                },
+                                "instruction": "Turn <span class=\"direction\">right</span> onto <span class=\"next-street\">E Fullerton Ave</span>. <span class=\"distance-description\">Go for <span class=\"length\">904 m</span>.</span>",
+                                "travelTime": 238,
+                                "length": 904,
+                                "id": "M6",
+                                "_type": "PrivateTransportManeuverType"
+                            },
+                            {
+                                "position": {
+                                    "latitude": 41.921618,
+                                    "longitude": -87.9038107
+                                },
+                                "instruction": "Turn <span class=\"direction\">left</span> onto <span class=\"next-street\">N Wolf Rd</span>. <span class=\"distance-description\">Go for <span class=\"length\">1.6 km</span>.</span>",
+                                "travelTime": 417,
+                                "length": 1604,
+                                "id": "M7",
+                                "_type": "PrivateTransportManeuverType"
+                            },
+                            {
+                                "position": {
+                                    "latitude": 41.907177,
+                                    "longitude": -87.9032314
+                                },
+                                "instruction": "Turn <span class=\"direction\">right</span> onto <span class=\"next-street\">W North Ave</span> <span class=\"number\">(IL-64)</span>. <span class=\"distance-description\">Go for <span class=\"length\">2.0 km</span>.</span>",
+                                "travelTime": 574,
+                                "length": 2031,
+                                "id": "M8",
+                                "_type": "PrivateTransportManeuverType"
+                            },
+                            {
+                                "position": {
+                                    "latitude": 41.9065225,
+                                    "longitude": -87.9277039
+                                },
+                                "instruction": "Turn <span class=\"direction\">left</span> onto <span class=\"next-street\">N Clinton Ave</span>. <span class=\"distance-description\">Go for <span class=\"length\">275 m</span>.</span>",
+                                "travelTime": 78,
+                                "length": 275,
+                                "id": "M9",
+                                "_type": "PrivateTransportManeuverType"
+                            },
+                            {
+                                "position": {
+                                    "latitude": 41.9040549,
+                                    "longitude": -87.9277253
+                                },
+                                "instruction": "Turn <span class=\"direction\">left</span> onto <span class=\"next-street\">E Third St</span>. <span class=\"distance-description\">Go for <span class=\"length\">249 m</span>.</span>",
+                                "travelTime": 63,
+                                "length": 249,
+                                "id": "M10",
+                                "_type": "PrivateTransportManeuverType"
+                            },
+                            {
+                                "position": {
+                                    "latitude": 41.9040334,
+                                    "longitude": -87.9247105
+                                },
+                                "instruction": "Continue on <span class=\"next-street\">N Caroline Ave</span>. <span class=\"distance-description\">Go for <span class=\"length\">96 m</span>.</span>",
+                                "travelTime": 37,
+                                "length": 96,
+                                "id": "M11",
+                                "_type": "PrivateTransportManeuverType"
+                            },
+                            {
+                                "position": {
+                                    "latitude": 41.9038832,
+                                    "longitude": -87.9236054
+                                },
+                                "instruction": "Turn <span class=\"direction\">slightly left</span>. <span class=\"distance-description\">Go for <span class=\"length\">113 m</span>.</span>",
+                                "travelTime": 28,
+                                "length": 113,
+                                "id": "M12",
+                                "_type": "PrivateTransportManeuverType"
+                            },
+                            {
+                                "position": {
+                                    "latitude": 41.9039047,
+                                    "longitude": -87.9222536
+                                },
+                                "instruction": "Turn <span class=\"direction\">left</span>. <span class=\"distance-description\">Go for <span class=\"length\">26 m</span>.</span>",
+                                "travelTime": 6,
+                                "length": 26,
+                                "id": "M13",
+                                "_type": "PrivateTransportManeuverType"
+                            },
+                            {
+                                "position": {
+                                    "latitude": 41.90413,
+                                    "longitude": -87.9223502
+                                },
+                                "instruction": "Arrive at your destination on the right.",
+                                "travelTime": 0,
+                                "length": 0,
+                                "id": "M14",
+                                "_type": "PrivateTransportManeuverType"
+                            }
+                        ]
+                    }
+                ],
+                "summary": {
+                    "distance": 12613,
+                    "baseTime": 3292,
+                    "flags": [
+                        "noThroughRoad",
+                        "builtUpArea",
+                        "park"
+                    ],
+                    "text": "The trip takes <span class=\"length\">12.6 km</span> and <span class=\"time\">55 mins</span>.",
+                    "travelTime": 3292,
+                    "_type": "RouteSummaryType"
+                }
+            }
+        ],
+        "language": "en-us"
+    }
+}

--- a/testdata/models/routing_pedestrian.json
+++ b/testdata/models/routing_pedestrian.json
@@ -1,0 +1,308 @@
+{
+    "response": {
+        "metaInfo": {
+            "timestamp": "2019-07-21T18:40:10Z",
+            "mapVersion": "8.30.98.154",
+            "moduleVersion": "7.2.201928-4478",
+            "interfaceVersion": "2.6.64",
+            "availableMapVersion": [
+                "8.30.98.154"
+            ]
+        },
+        "route": [
+            {
+                "waypoint": [
+                    {
+                        "linkId": "-1230414527",
+                        "mappedPosition": {
+                            "latitude": 41.9797859,
+                            "longitude": -87.8790879
+                        },
+                        "originalPosition": {
+                            "latitude": 41.9798,
+                            "longitude": -87.8801
+                        },
+                        "type": "stopOver",
+                        "spot": 0.5079365,
+                        "sideOfStreet": "right",
+                        "mappedRoadName": "Mannheim Rd",
+                        "label": "Mannheim Rd - US-12",
+                        "shapeIndex": 0,
+                        "source": "user"
+                    },
+                    {
+                        "linkId": "+924115108",
+                        "mappedPosition": {
+                            "latitude": 41.90413,
+                            "longitude": -87.9223502
+                        },
+                        "originalPosition": {
+                            "latitude": 41.9043,
+                            "longitude": -87.9216001
+                        },
+                        "type": "stopOver",
+                        "spot": 0.1925926,
+                        "sideOfStreet": "right",
+                        "mappedRoadName": "",
+                        "label": "",
+                        "shapeIndex": 122,
+                        "source": "user"
+                    }
+                ],
+                "mode": {
+                    "type": "fastest",
+                    "transportModes": [
+                        "pedestrian"
+                    ],
+                    "trafficMode": "disabled",
+                    "feature": []
+                },
+                "leg": [
+                    {
+                        "start": {
+                            "linkId": "-1230414527",
+                            "mappedPosition": {
+                                "latitude": 41.9797859,
+                                "longitude": -87.8790879
+                            },
+                            "originalPosition": {
+                                "latitude": 41.9798,
+                                "longitude": -87.8801
+                            },
+                            "type": "stopOver",
+                            "spot": 0.5079365,
+                            "sideOfStreet": "right",
+                            "mappedRoadName": "Mannheim Rd",
+                            "label": "Mannheim Rd - US-12",
+                            "shapeIndex": 0,
+                            "source": "user"
+                        },
+                        "end": {
+                            "linkId": "+924115108",
+                            "mappedPosition": {
+                                "latitude": 41.90413,
+                                "longitude": -87.9223502
+                            },
+                            "originalPosition": {
+                                "latitude": 41.9043,
+                                "longitude": -87.9216001
+                            },
+                            "type": "stopOver",
+                            "spot": 0.1925926,
+                            "sideOfStreet": "right",
+                            "mappedRoadName": "",
+                            "label": "",
+                            "shapeIndex": 122,
+                            "source": "user"
+                        },
+                        "length": 12533,
+                        "travelTime": 12631,
+                        "maneuver": [
+                            {
+                                "position": {
+                                    "latitude": 41.9797859,
+                                    "longitude": -87.8790879
+                                },
+                                "instruction": "Head <span class=\"heading\">south</span> on <span class=\"street\">Mannheim Rd</span>. <span class=\"distance-description\">Go for <span class=\"length\">848 m</span>.</span>",
+                                "travelTime": 848,
+                                "length": 848,
+                                "id": "M1",
+                                "_type": "PrivateTransportManeuverType"
+                            },
+                            {
+                                "position": {
+                                    "latitude": 41.9722581,
+                                    "longitude": -87.8776109
+                                },
+                                "instruction": "Take the street on the <span class=\"direction\">left</span>, <span class=\"next-street\">Mannheim Rd</span>. <span class=\"distance-description\">Go for <span class=\"length\">4.2 km</span>.</span>",
+                                "travelTime": 4239,
+                                "length": 4227,
+                                "id": "M2",
+                                "_type": "PrivateTransportManeuverType"
+                            },
+                            {
+                                "position": {
+                                    "latitude": 41.9364238,
+                                    "longitude": -87.8849387
+                                },
+                                "instruction": "Turn <span class=\"direction\">right</span> onto <span class=\"next-street\">W Belmont Ave</span>. <span class=\"distance-description\">Go for <span class=\"length\">595 m</span>.</span>",
+                                "travelTime": 605,
+                                "length": 595,
+                                "id": "M3",
+                                "_type": "PrivateTransportManeuverType"
+                            },
+                            {
+                                "position": {
+                                    "latitude": 41.9362521,
+                                    "longitude": -87.8921163
+                                },
+                                "instruction": "Turn <span class=\"direction\">left</span> onto <span class=\"next-street\">Cullerton St</span>. <span class=\"distance-description\">Go for <span class=\"length\">406 m</span>.</span>",
+                                "travelTime": 411,
+                                "length": 406,
+                                "id": "M4",
+                                "_type": "PrivateTransportManeuverType"
+                            },
+                            {
+                                "position": {
+                                    "latitude": 41.9326043,
+                                    "longitude": -87.8919983
+                                },
+                                "instruction": "Turn <span class=\"direction\">right</span> onto <span class=\"next-street\">Cullerton St</span>. <span class=\"distance-description\">Go for <span class=\"length\">1.2 km</span>.</span>",
+                                "travelTime": 1249,
+                                "length": 1239,
+                                "id": "M5",
+                                "_type": "PrivateTransportManeuverType"
+                            },
+                            {
+                                "position": {
+                                    "latitude": 41.9217896,
+                                    "longitude": -87.8928781
+                                },
+                                "instruction": "Turn <span class=\"direction\">right</span> onto <span class=\"next-street\">E Fullerton Ave</span>. <span class=\"distance-description\">Go for <span class=\"length\">786 m</span>.</span>",
+                                "travelTime": 796,
+                                "length": 786,
+                                "id": "M6",
+                                "_type": "PrivateTransportManeuverType"
+                            },
+                            {
+                                "position": {
+                                    "latitude": 41.9216394,
+                                    "longitude": -87.9023838
+                                },
+                                "instruction": "Turn <span class=\"direction\">left</span> onto <span class=\"next-street\">La Porte Ave</span>. <span class=\"distance-description\">Go for <span class=\"length\">424 m</span>.</span>",
+                                "travelTime": 430,
+                                "length": 424,
+                                "id": "M7",
+                                "_type": "PrivateTransportManeuverType"
+                            },
+                            {
+                                "position": {
+                                    "latitude": 41.9180024,
+                                    "longitude": -87.9028559
+                                },
+                                "instruction": "Turn <span class=\"direction\">right</span> onto <span class=\"next-street\">E Palmer Ave</span>. <span class=\"distance-description\">Go for <span class=\"length\">864 m</span>.</span>",
+                                "travelTime": 875,
+                                "length": 864,
+                                "id": "M8",
+                                "_type": "PrivateTransportManeuverType"
+                            },
+                            {
+                                "position": {
+                                    "latitude": 41.9175196,
+                                    "longitude": -87.9132199
+                                },
+                                "instruction": "Turn <span class=\"direction\">left</span> onto <span class=\"next-street\">N Railroad Ave</span>. <span class=\"distance-description\">Go for <span class=\"length\">1.2 km</span>.</span>",
+                                "travelTime": 1180,
+                                "length": 1170,
+                                "id": "M9",
+                                "_type": "PrivateTransportManeuverType"
+                            },
+                            {
+                                "position": {
+                                    "latitude": 41.9070268,
+                                    "longitude": -87.9130161
+                                },
+                                "instruction": "Turn <span class=\"direction\">right</span> onto <span class=\"next-street\">W North Ave</span>. <span class=\"distance-description\">Go for <span class=\"length\">638 m</span>.</span>",
+                                "travelTime": 638,
+                                "length": 638,
+                                "id": "M10",
+                                "_type": "PrivateTransportManeuverType"
+                            },
+                            {
+                                "position": {
+                                    "latitude": 41.9068551,
+                                    "longitude": -87.9207087
+                                },
+                                "instruction": "Take the street on the <span class=\"direction\">left</span>, <span class=\"next-street\">E North Ave</span>. <span class=\"distance-description\">Go for <span class=\"length\">354 m</span>.</span>",
+                                "travelTime": 354,
+                                "length": 354,
+                                "id": "M11",
+                                "_type": "PrivateTransportManeuverType"
+                            },
+                            {
+                                "position": {
+                                    "latitude": 41.9065869,
+                                    "longitude": -87.9249573
+                                },
+                                "instruction": "Take the street on the <span class=\"direction\">left</span>, <span class=\"next-street\">E North Ave</span>. <span class=\"distance-description\">Go for <span class=\"length\">228 m</span>.</span>",
+                                "travelTime": 242,
+                                "length": 228,
+                                "id": "M12",
+                                "_type": "PrivateTransportManeuverType"
+                            },
+                            {
+                                "position": {
+                                    "latitude": 41.9065225,
+                                    "longitude": -87.9277039
+                                },
+                                "instruction": "Turn <span class=\"direction\">left</span>. <span class=\"distance-description\">Go for <span class=\"length\">409 m</span>.</span>",
+                                "travelTime": 419,
+                                "length": 409,
+                                "id": "M13",
+                                "_type": "PrivateTransportManeuverType"
+                            },
+                            {
+                                "position": {
+                                    "latitude": 41.9040334,
+                                    "longitude": -87.9260409
+                                },
+                                "instruction": "Turn <span class=\"direction\">left</span> onto <span class=\"next-street\">E Third St</span>. <span class=\"distance-description\">Go for <span class=\"length\">206 m</span>.</span>",
+                                "travelTime": 206,
+                                "length": 206,
+                                "id": "M14",
+                                "_type": "PrivateTransportManeuverType"
+                            },
+                            {
+                                "position": {
+                                    "latitude": 41.9038832,
+                                    "longitude": -87.9236054
+                                },
+                                "instruction": "Turn <span class=\"direction\">left</span>. <span class=\"distance-description\">Go for <span class=\"length\">113 m</span>.</span>",
+                                "travelTime": 113,
+                                "length": 113,
+                                "id": "M15",
+                                "_type": "PrivateTransportManeuverType"
+                            },
+                            {
+                                "position": {
+                                    "latitude": 41.9039047,
+                                    "longitude": -87.9222536
+                                },
+                                "instruction": "Turn <span class=\"direction\">left</span>. <span class=\"distance-description\">Go for <span class=\"length\">26 m</span>.</span>",
+                                "travelTime": 26,
+                                "length": 26,
+                                "id": "M16",
+                                "_type": "PrivateTransportManeuverType"
+                            },
+                            {
+                                "position": {
+                                    "latitude": 41.90413,
+                                    "longitude": -87.9223502
+                                },
+                                "instruction": "Arrive at your destination on the right.",
+                                "travelTime": 0,
+                                "length": 0,
+                                "id": "M17",
+                                "_type": "PrivateTransportManeuverType"
+                            }
+                        ]
+                    }
+                ],
+                "summary": {
+                    "distance": 12533,
+                    "baseTime": 12631,
+                    "flags": [
+                        "noThroughRoad",
+                        "builtUpArea",
+                        "park",
+                        "privateRoad"
+                    ],
+                    "text": "The trip takes <span class=\"length\">12.5 km</span> and <span class=\"time\">3:31 h</span>.",
+                    "travelTime": 12631,
+                    "_type": "RouteSummaryType"
+                }
+            }
+        ],
+        "language": "en-us"
+    }
+}

--- a/testdata/models/routing_public.json
+++ b/testdata/models/routing_public.json
@@ -1,0 +1,294 @@
+{
+    "response": {
+        "metaInfo": {
+            "timestamp": "2019-07-21T18:40:37Z",
+            "mapVersion": "8.30.98.154",
+            "moduleVersion": "7.2.201928-4478",
+            "interfaceVersion": "2.6.64",
+            "availableMapVersion": [
+                "8.30.98.154"
+            ]
+        },
+        "route": [
+            {
+                "waypoint": [
+                    {
+                        "linkId": "-1230414527",
+                        "mappedPosition": {
+                            "latitude": 41.9797859,
+                            "longitude": -87.8790879
+                        },
+                        "originalPosition": {
+                            "latitude": 41.9798,
+                            "longitude": -87.8801
+                        },
+                        "type": "stopOver",
+                        "spot": 0.5079365,
+                        "sideOfStreet": "right",
+                        "mappedRoadName": "Mannheim Rd",
+                        "label": "Mannheim Rd - US-12",
+                        "shapeIndex": 0,
+                        "source": "user"
+                    },
+                    {
+                        "linkId": "+924115108",
+                        "mappedPosition": {
+                            "latitude": 41.90413,
+                            "longitude": -87.9223502
+                        },
+                        "originalPosition": {
+                            "latitude": 41.9043,
+                            "longitude": -87.9216001
+                        },
+                        "type": "stopOver",
+                        "spot": 0.1925926,
+                        "sideOfStreet": "right",
+                        "mappedRoadName": "",
+                        "label": "",
+                        "shapeIndex": 191,
+                        "source": "user"
+                    }
+                ],
+                "mode": {
+                    "type": "fastest",
+                    "transportModes": [
+                        "publicTransport"
+                    ],
+                    "trafficMode": "disabled",
+                    "feature": []
+                },
+                "leg": [
+                    {
+                        "start": {
+                            "linkId": "-1230414527",
+                            "mappedPosition": {
+                                "latitude": 41.9797859,
+                                "longitude": -87.8790879
+                            },
+                            "originalPosition": {
+                                "latitude": 41.9798,
+                                "longitude": -87.8801
+                            },
+                            "type": "stopOver",
+                            "spot": 0.5079365,
+                            "sideOfStreet": "right",
+                            "mappedRoadName": "Mannheim Rd",
+                            "label": "Mannheim Rd - US-12",
+                            "shapeIndex": 0,
+                            "source": "user"
+                        },
+                        "end": {
+                            "linkId": "+924115108",
+                            "mappedPosition": {
+                                "latitude": 41.90413,
+                                "longitude": -87.9223502
+                            },
+                            "originalPosition": {
+                                "latitude": 41.9043,
+                                "longitude": -87.9216001
+                            },
+                            "type": "stopOver",
+                            "spot": 0.1925926,
+                            "sideOfStreet": "right",
+                            "mappedRoadName": "",
+                            "label": "",
+                            "shapeIndex": 191,
+                            "source": "user"
+                        },
+                        "length": 22325,
+                        "travelTime": 5350,
+                        "maneuver": [
+                            {
+                                "position": {
+                                    "latitude": 41.9797859,
+                                    "longitude": -87.8790879
+                                },
+                                "instruction": "Head <span class=\"heading\">south</span> on <span class=\"street\">Mannheim Rd</span>. <span class=\"distance-description\">Go for <span class=\"length\">848 m</span>.</span>",
+                                "travelTime": 848,
+                                "length": 848,
+                                "id": "M1",
+                                "_type": "PrivateTransportManeuverType"
+                            },
+                            {
+                                "position": {
+                                    "latitude": 41.9722581,
+                                    "longitude": -87.8776109
+                                },
+                                "instruction": "Take the street on the <span class=\"direction\">left</span>, <span class=\"next-street\">Mannheim Rd</span>. <span class=\"distance-description\">Go for <span class=\"length\">825 m</span>.</span>",
+                                "travelTime": 825,
+                                "length": 825,
+                                "id": "M2",
+                                "_type": "PrivateTransportManeuverType"
+                            },
+                            {
+                                "position": {
+                                    "latitude": 41.9650483,
+                                    "longitude": -87.8769565
+                                },
+                                "instruction": "Go to the stop <span class=\"station\">Mannheim/Lawrence</span> and take the <span class=\"transit\">bus</span> <span class=\"line\">332</span> toward <span class=\"destination\">Palmer/Schiller</span>. <span class=\"distance-description\">Follow for <span class=\"stops\">7 stops</span>.</span>",
+                                "travelTime": 475,
+                                "length": 4360,
+                                "id": "M3",
+                                "stopName": "Mannheim/Lawrence",
+                                "_type": "PublicTransportManeuverType"
+                            },
+                            {
+                                "position": {
+                                    "latitude": 41.9541478,
+                                    "longitude": -87.9133594
+                                },
+                                "instruction": "Get off at <span class=\"station\">Irving Park/Taft</span>.",
+                                "travelTime": 0,
+                                "length": 0,
+                                "id": "M4",
+                                "stopName": "Irving Park/Taft",
+                                "_type": "PublicTransportManeuverType"
+                            },
+                            {
+                                "position": {
+                                    "latitude": 41.9541478,
+                                    "longitude": -87.9133594
+                                },
+                                "instruction": "Take the <span class=\"transit\">bus</span> <span class=\"line\">332</span> toward <span class=\"destination\">Cargo Rd./Delta Cargo</span>. <span class=\"distance-description\">Follow for <span class=\"stops\">1 stop</span>.</span>",
+                                "travelTime": 155,
+                                "length": 3505,
+                                "id": "M5",
+                                "stopName": "Irving Park/Taft",
+                                "_type": "PublicTransportManeuverType"
+                            },
+                            {
+                                "position": {
+                                    "latitude": 41.9599199,
+                                    "longitude": -87.9162776
+                                },
+                                "instruction": "Get off at <span class=\"station\">Cargo Rd./S. Access Rd./Lufthansa</span>.",
+                                "travelTime": 0,
+                                "length": 0,
+                                "id": "M6",
+                                "stopName": "Cargo Rd./S. Access Rd./Lufthansa",
+                                "_type": "PublicTransportManeuverType"
+                            },
+                            {
+                                "position": {
+                                    "latitude": 41.9599199,
+                                    "longitude": -87.9162776
+                                },
+                                "instruction": "Take the <span class=\"transit\">bus</span> <span class=\"line\">332</span> toward <span class=\"destination\">Palmer/Schiller</span>. <span class=\"distance-description\">Follow for <span class=\"stops\">41 stops</span>.</span>",
+                                "travelTime": 1510,
+                                "length": 11261,
+                                "id": "M7",
+                                "stopName": "Cargo Rd./S. Access Rd./Lufthansa",
+                                "_type": "PublicTransportManeuverType"
+                            },
+                            {
+                                "position": {
+                                    "latitude": 41.9041729,
+                                    "longitude": -87.9399669
+                                },
+                                "instruction": "Get off at <span class=\"station\">York/Third</span>.",
+                                "travelTime": 0,
+                                "length": 0,
+                                "id": "M8",
+                                "stopName": "York/Third",
+                                "nextRoadName": "N York St",
+                                "_type": "PublicTransportManeuverType"
+                            },
+                            {
+                                "position": {
+                                    "latitude": 41.9041729,
+                                    "longitude": -87.9399669
+                                },
+                                "instruction": "Head <span class=\"heading\">east</span> on <span class=\"street\">N York St</span>. <span class=\"distance-description\">Go for <span class=\"length\">33 m</span>.</span>",
+                                "travelTime": 43,
+                                "length": 33,
+                                "id": "M9",
+                                "_type": "PrivateTransportManeuverType"
+                            },
+                            {
+                                "position": {
+                                    "latitude": 41.9039476,
+                                    "longitude": -87.9398811
+                                },
+                                "instruction": "Turn <span class=\"direction\">left</span> onto <span class=\"next-street\">E Third St</span>. <span class=\"distance-description\">Go for <span class=\"length\">1.4 km</span>.</span>",
+                                "travelTime": 1355,
+                                "length": 1354,
+                                "id": "M10",
+                                "_type": "PrivateTransportManeuverType"
+                            },
+                            {
+                                "position": {
+                                    "latitude": 41.9038832,
+                                    "longitude": -87.9236054
+                                },
+                                "instruction": "Turn <span class=\"direction\">left</span>. <span class=\"distance-description\">Go for <span class=\"length\">113 m</span>.</span>",
+                                "travelTime": 113,
+                                "length": 113,
+                                "id": "M11",
+                                "_type": "PrivateTransportManeuverType"
+                            },
+                            {
+                                "position": {
+                                    "latitude": 41.9039047,
+                                    "longitude": -87.9222536
+                                },
+                                "instruction": "Turn <span class=\"direction\">left</span>. <span class=\"distance-description\">Go for <span class=\"length\">26 m</span>.</span>",
+                                "travelTime": 26,
+                                "length": 26,
+                                "id": "M12",
+                                "_type": "PrivateTransportManeuverType"
+                            },
+                            {
+                                "position": {
+                                    "latitude": 41.90413,
+                                    "longitude": -87.9223502
+                                },
+                                "instruction": "Arrive at your destination on the right.",
+                                "travelTime": 0,
+                                "length": 0,
+                                "id": "M13",
+                                "_type": "PrivateTransportManeuverType"
+                            }
+                        ]
+                    }
+                ],
+                "publicTransportLine": [
+                    {
+                        "lineName": "332",
+                        "companyName": "",
+                        "destination": "Palmer/Schiller",
+                        "type": "busPublic",
+                        "id": "L1"
+                    },
+                    {
+                        "lineName": "332",
+                        "companyName": "",
+                        "destination": "Cargo Rd./Delta Cargo",
+                        "type": "busPublic",
+                        "id": "L2"
+                    },
+                    {
+                        "lineName": "332",
+                        "companyName": "",
+                        "destination": "Palmer/Schiller",
+                        "type": "busPublic",
+                        "id": "L3"
+                    }
+                ],
+                "summary": {
+                    "distance": 22325,
+                    "baseTime": 5350,
+                    "flags": [
+                        "noThroughRoad",
+                        "builtUpArea",
+                        "park"
+                    ],
+                    "text": "The trip takes <span class=\"length\">22.3 km</span> and <span class=\"time\">1:29 h</span>.",
+                    "travelTime": 5350,
+                    "departure": "1970-01-01T00:00:00Z",
+                    "_type": "PublicTransportRouteSummaryType"
+                }
+            }
+        ],
+        "language": "en-us"
+    }
+}

--- a/testdata/models/routing_public_time_table.json
+++ b/testdata/models/routing_public_time_table.json
@@ -1,0 +1,308 @@
+{
+    "response": {
+        "metaInfo": {
+            "timestamp": "2019-08-06T06:43:24Z",
+            "mapVersion": "8.30.99.152",
+            "moduleVersion": "7.2.201931-4739",
+            "interfaceVersion": "2.6.66",
+            "availableMapVersion": [
+                "8.30.99.152"
+            ]
+        },
+        "route": [
+            {
+                "waypoint": [
+                    {
+                        "linkId": "-1230414527",
+                        "mappedPosition": {
+                            "latitude": 41.9797859,
+                            "longitude": -87.8790879
+                        },
+                        "originalPosition": {
+                            "latitude": 41.9798,
+                            "longitude": -87.8801
+                        },
+                        "type": "stopOver",
+                        "spot": 0.5079365,
+                        "sideOfStreet": "right",
+                        "mappedRoadName": "Mannheim Rd",
+                        "label": "Mannheim Rd - US-12",
+                        "shapeIndex": 0,
+                        "source": "user"
+                    },
+                    {
+                        "linkId": "+924115108",
+                        "mappedPosition": {
+                            "latitude": 41.90413,
+                            "longitude": -87.9223502
+                        },
+                        "originalPosition": {
+                            "latitude": 41.9043,
+                            "longitude": -87.9216001
+                        },
+                        "type": "stopOver",
+                        "spot": 0.1925926,
+                        "sideOfStreet": "right",
+                        "mappedRoadName": "",
+                        "label": "",
+                        "shapeIndex": 111,
+                        "source": "user"
+                    }
+                ],
+                "mode": {
+                    "type": "fastest",
+                    "transportModes": [
+                        "publicTransportTimeTable"
+                    ],
+                    "trafficMode": "disabled",
+                    "feature": []
+                },
+                "leg": [
+                    {
+                        "start": {
+                            "linkId": "-1230414527",
+                            "mappedPosition": {
+                                "latitude": 41.9797859,
+                                "longitude": -87.8790879
+                            },
+                            "originalPosition": {
+                                "latitude": 41.9798,
+                                "longitude": -87.8801
+                            },
+                            "type": "stopOver",
+                            "spot": 0.5079365,
+                            "sideOfStreet": "right",
+                            "mappedRoadName": "Mannheim Rd",
+                            "label": "Mannheim Rd - US-12",
+                            "shapeIndex": 0,
+                            "source": "user"
+                        },
+                        "end": {
+                            "linkId": "+924115108",
+                            "mappedPosition": {
+                                "latitude": 41.90413,
+                                "longitude": -87.9223502
+                            },
+                            "originalPosition": {
+                                "latitude": 41.9043,
+                                "longitude": -87.9216001
+                            },
+                            "type": "stopOver",
+                            "spot": 0.1925926,
+                            "sideOfStreet": "right",
+                            "mappedRoadName": "",
+                            "label": "",
+                            "shapeIndex": 111,
+                            "source": "user"
+                        },
+                        "length": 14775,
+                        "travelTime": 4784,
+                        "maneuver": [
+                            {
+                                "position": {
+                                    "latitude": 41.9797859,
+                                    "longitude": -87.8790879
+                                },
+                                "instruction": "Head <span class=\"heading\">south</span> on <span class=\"street\">Mannheim Rd</span>. <span class=\"distance-description\">Go for <span class=\"length\">848 m</span>.</span>",
+                                "travelTime": 848,
+                                "length": 848,
+                                "id": "M1",
+                                "_type": "PrivateTransportManeuverType"
+                            },
+                            {
+                                "position": {
+                                    "latitude": 41.9722581,
+                                    "longitude": -87.8776109
+                                },
+                                "instruction": "Take the street on the <span class=\"direction\">left</span>, <span class=\"next-street\">Mannheim Rd</span>. <span class=\"distance-description\">Go for <span class=\"length\">812 m</span>.</span>",
+                                "travelTime": 812,
+                                "length": 812,
+                                "id": "M2",
+                                "_type": "PrivateTransportManeuverType"
+                            },
+                            {
+                                "position": {
+                                    "latitude": 41.965051,
+                                    "longitude": -87.8769591
+                                },
+                                "instruction": "Go to the <span class=\"company\">Bus</span> stop <span class=\"station\">Mannheim/Lawrence</span> and take the <span class=\"transit\">bus</span> <span class=\"line\">330</span> toward <span class=\"destination\">Archer/Harlem (Terminal)</span>. <span class=\"distance-description\">Follow for <span class=\"stops\">33 stops</span>.</span>",
+                                "travelTime": 900,
+                                "length": 7815,
+                                "id": "M3",
+                                "stopName": "Mannheim/Lawrence",
+                                "_type": "PublicTransportManeuverType"
+                            },
+                            {
+                                "position": {
+                                    "latitude": 41.896836,
+                                    "longitude": -87.883771
+                                },
+                                "instruction": "Get off at <span class=\"station\">Mannheim/Lake</span>.",
+                                "travelTime": 0,
+                                "length": 0,
+                                "id": "M4",
+                                "stopName": "Mannheim/Lake",
+                                "_type": "PublicTransportManeuverType"
+                            },
+                            {
+                                "position": {
+                                    "latitude": 41.896836,
+                                    "longitude": -87.883771
+                                },
+                                "instruction": "Walk to <span class=\"company\">Bus</span> <span class=\"station\">Lake/Mannheim</span>.",
+                                "travelTime": 300,
+                                "length": 72,
+                                "id": "M5",
+                                "_type": "PrivateTransportManeuverType"
+                            },
+                            {
+                                "position": {
+                                    "latitude": 41.897263,
+                                    "longitude": -87.8842648
+                                },
+                                "instruction": "Take the <span class=\"transit\">bus</span> <span class=\"line\">309</span> toward <span class=\"destination\">Elmhurst Metra Station</span>. <span class=\"distance-description\">Follow for <span class=\"stops\">18 stops</span>.</span>",
+                                "travelTime": 1020,
+                                "length": 4362,
+                                "id": "M6",
+                                "stopName": "Lake/Mannheim",
+                                "_type": "PublicTransportManeuverType"
+                            },
+                            {
+                                "position": {
+                                    "latitude": 41.9066347,
+                                    "longitude": -87.928671
+                                },
+                                "instruction": "Get off at <span class=\"station\">North/Berteau</span>.",
+                                "travelTime": 0,
+                                "length": 0,
+                                "id": "M7",
+                                "stopName": "North/Berteau",
+                                "nextRoadName": "E Berteau Ave",
+                                "_type": "PublicTransportManeuverType"
+                            },
+                            {
+                                "position": {
+                                    "latitude": 41.9066347,
+                                    "longitude": -87.928671
+                                },
+                                "instruction": "Head <span class=\"heading\">north</span> on <span class=\"street\">E Berteau Ave</span>. <span class=\"distance-description\">Go for <span class=\"length\">23 m</span>.</span>",
+                                "travelTime": 40,
+                                "length": 23,
+                                "id": "M8",
+                                "_type": "PrivateTransportManeuverType"
+                            },
+                            {
+                                "position": {
+                                    "latitude": 41.9067693,
+                                    "longitude": -87.9284549
+                                },
+                                "instruction": "Turn <span class=\"direction\">right</span> onto <span class=\"next-street\">E Berteau Ave</span>. <span class=\"distance-description\">Go for <span class=\"length\">40 m</span>.</span>",
+                                "travelTime": 44,
+                                "length": 40,
+                                "id": "M9",
+                                "_type": "PrivateTransportManeuverType"
+                            },
+                            {
+                                "position": {
+                                    "latitude": 41.9065011,
+                                    "longitude": -87.9282939
+                                },
+                                "instruction": "Turn <span class=\"direction\">left</span> onto <span class=\"next-street\">E North Ave</span>. <span class=\"distance-description\">Go for <span class=\"length\">49 m</span>.</span>",
+                                "travelTime": 56,
+                                "length": 49,
+                                "id": "M10",
+                                "_type": "PrivateTransportManeuverType"
+                            },
+                            {
+                                "position": {
+                                    "latitude": 41.9065225,
+                                    "longitude": -87.9277039
+                                },
+                                "instruction": "Turn <span class=\"direction\">slightly right</span>. <span class=\"distance-description\">Go for <span class=\"length\">409 m</span>.</span>",
+                                "travelTime": 419,
+                                "length": 409,
+                                "id": "M11",
+                                "_type": "PrivateTransportManeuverType"
+                            },
+                            {
+                                "position": {
+                                    "latitude": 41.9040334,
+                                    "longitude": -87.9260409
+                                },
+                                "instruction": "Turn <span class=\"direction\">left</span> onto <span class=\"next-street\">E Third St</span>. <span class=\"distance-description\">Go for <span class=\"length\">206 m</span>.</span>",
+                                "travelTime": 206,
+                                "length": 206,
+                                "id": "M12",
+                                "_type": "PrivateTransportManeuverType"
+                            },
+                            {
+                                "position": {
+                                    "latitude": 41.9038832,
+                                    "longitude": -87.9236054
+                                },
+                                "instruction": "Turn <span class=\"direction\">left</span>. <span class=\"distance-description\">Go for <span class=\"length\">113 m</span>.</span>",
+                                "travelTime": 113,
+                                "length": 113,
+                                "id": "M13",
+                                "_type": "PrivateTransportManeuverType"
+                            },
+                            {
+                                "position": {
+                                    "latitude": 41.9039047,
+                                    "longitude": -87.9222536
+                                },
+                                "instruction": "Turn <span class=\"direction\">left</span>. <span class=\"distance-description\">Go for <span class=\"length\">26 m</span>.</span>",
+                                "travelTime": 26,
+                                "length": 26,
+                                "id": "M14",
+                                "_type": "PrivateTransportManeuverType"
+                            },
+                            {
+                                "position": {
+                                    "latitude": 41.90413,
+                                    "longitude": -87.9223502
+                                },
+                                "instruction": "Arrive at your destination on the right.",
+                                "travelTime": 0,
+                                "length": 0,
+                                "id": "M15",
+                                "_type": "PrivateTransportManeuverType"
+                            }
+                        ]
+                    }
+                ],
+                "publicTransportLine": [
+                    {
+                        "lineName": "330",
+                        "companyName": "PACE",
+                        "destination": "Archer/Harlem (Terminal)",
+                        "type": "busPublic",
+                        "id": "L1"
+                    },
+                    {
+                        "lineName": "309",
+                        "companyName": "PACE",
+                        "destination": "Elmhurst Metra Station",
+                        "type": "busPublic",
+                        "id": "L2"
+                    }
+                ],
+                "summary": {
+                    "distance": 14775,
+                    "baseTime": 4784,
+                    "flags": [
+                        "noThroughRoad",
+                        "builtUpArea",
+                        "park"
+                    ],
+                    "text": "The trip takes <span class=\"length\">14.8 km</span> and <span class=\"time\">1:20 h</span>.",
+                    "travelTime": 4784,
+                    "departure": "2019-08-06T05:09:20-05:00",
+                    "timetableExpiration": "2019-08-04T00:00:00Z",
+                    "_type": "PublicTransportRouteSummaryType"
+                }
+            }
+        ],
+        "language": "en-us"
+    }
+}

--- a/tests/test_routing_api.py
+++ b/tests/test_routing_api.py
@@ -20,6 +20,16 @@ class RoutingApiTest(unittest.TestCase):
         self.assertEqual(self._api._base_url, 'https://route.cit.api.here.com/routing/7.2/calculateroute.json')
 
     @responses.activate
+    def test_bicycleroute_withdefaultmodes_whensucceed(self):
+        with codecs.open('testdata/models/routing_bicycle.json', mode='r', encoding='utf-8') as f:
+            expectedResponse = f.read()
+        responses.add(responses.GET, 'https://route.cit.api.here.com/routing/7.2/calculateroute.json',
+                  expectedResponse, status=200)
+        response = self._api.bicycle_route([41.9798, -87.8801], [41.9043, -87.9216])
+        self.assertTrue(response)
+        self.assertIsInstance(response, herepy.RoutingResponse)
+
+    @responses.activate
     def test_carroute_whensucceed(self):
         with codecs.open('testdata/models/routing.json', mode='r', encoding='utf-8') as f:
             expectedResponse = f.read()
@@ -69,7 +79,7 @@ class RoutingApiTest(unittest.TestCase):
 
     @responses.activate
     def test_pedastrianroute_whensucceed(self):
-        with codecs.open('testdata/models/routing.json', mode='r', encoding='utf-8') as f:
+        with codecs.open('testdata/models/routing_pedestrian.json', mode='r', encoding='utf-8') as f:
             expectedResponse = f.read()
         responses.add(responses.GET, 'https://route.cit.api.here.com/routing/7.2/calculateroute.json',
                   expectedResponse, status=200)
@@ -79,7 +89,7 @@ class RoutingApiTest(unittest.TestCase):
 
     @responses.activate
     def test_pedastrianroute_withdefaultmodes_whensucceed(self):
-        with codecs.open('testdata/models/routing.json', mode='r', encoding='utf-8') as f:
+        with codecs.open('testdata/models/routing_pedestrian.json', mode='r', encoding='utf-8') as f:
             expectedResponse = f.read()
         responses.add(responses.GET, 'https://route.cit.api.here.com/routing/7.2/calculateroute.json',
                   expectedResponse, status=200)
@@ -165,7 +175,7 @@ class RoutingApiTest(unittest.TestCase):
 
     @responses.activate
     def test_publictransport_whensucceed(self):
-        with codecs.open('testdata/models/routing.json', mode='r', encoding='utf-8') as f:
+        with codecs.open('testdata/models/routing_public.json', mode='r', encoding='utf-8') as f:
             expectedResponse = f.read()
         responses.add(responses.GET, 'https://route.cit.api.here.com/routing/7.2/calculateroute.json',
                   expectedResponse, status=200)
@@ -178,7 +188,7 @@ class RoutingApiTest(unittest.TestCase):
 
     @responses.activate
     def test_publictransport_withdefaultmodes_whensucceed(self):
-        with codecs.open('testdata/models/routing.json', mode='r', encoding='utf-8') as f:
+        with codecs.open('testdata/models/routing_public.json', mode='r', encoding='utf-8') as f:
             expectedResponse = f.read()
         responses.add(responses.GET, 'https://route.cit.api.here.com/routing/7.2/calculateroute.json',
                   expectedResponse, status=200)
@@ -220,6 +230,18 @@ class RoutingApiTest(unittest.TestCase):
                   expectedResponse, status=200)
         with self.assertRaises(herepy.NoRouteFoundError):
             self._api.public_transport([11.0, 12.0], [47.013399, -10.171986], True)
+
+    @responses.activate
+    def test_publictransporttimetable_withdefaultmodes_whensucceed(self):
+        with codecs.open('testdata/models/routing_public_time_table.json', mode='r', encoding='utf-8') as f:
+            expectedResponse = f.read()
+        responses.add(responses.GET, 'https://route.cit.api.here.com/routing/7.2/calculateroute.json',
+                  expectedResponse, status=200)
+        response = self._api.public_transport_timetable([11.0, 12.0],
+                                              [15.0, 16.0],
+                                              True)
+        self.assertTrue(response)
+        self.assertIsInstance(response, herepy.RoutingResponse)
 
     @responses.activate
     def test_locationnearmotorway_whensucceed(self):


### PR DESCRIPTION
This adds an addition attribute `route_short` to the `RoutingResponse` which shows a short description of the route like the Waze or Google API does.

Route descriptions look like this:

```python
"Mannheim Rd; W Belmont Ave; Cullerton St; N Landen Dr; "
"E Fullerton Ave; N Wolf Rd; W North Ave; N Clinton Ave; "
"E Third St; N Caroline Ave"
````

```python
"332 - Palmer/Schiller; 332 - Cargo Rd./Delta Cargo; " "332 - Palmer/Schiller"
````

Furthermore the modes `bicycle` and `publicTransportTimetable` are added.