### PR TITLE
Fix calculate route time format

### DIFF
--- a/herepy/public_transit_api.py
+++ b/herepy/public_transit_api.py
@@ -292,7 +292,7 @@ class PublicTransitApi(HEREApi):
         """
 
         data = {'dep': str.format('{0},{1}', departure[0], departure[1]),
-                'arr': str.format('{0}.{1}', arrival[0], arrival[1]),
+                'arr': str.format('{0},{1}', arrival[0], arrival[1]),
                 'time': time,
                 'app_id': self._app_id,
                 'app_code': self._app_code,

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+"""HerePY test package initialization"""


### PR DESCRIPTION
### Issue

When calculating a route time using the Public Transport API, the coordinates string associated with the arrival waypoint was formed using a `.` instead of `,` which lead to a bad request response from the server.

### Changes

- Replace `.` with a `,` when defining the arrival coordinates.

### Tests

- Manually tested using personal development keys against the HereAPI.