### PR TITLE
Start using new endpoints.

### DIFF
--- a/herepy/destination_weather_api.py
+++ b/herepy/destination_weather_api.py
@@ -14,19 +14,17 @@ from herepy.here_enum import WeatherProductType
 class DestinationWeatherApi(HEREApi):
     """A python interface into the HERE Destination Weather API"""
 
-    def __init__(self, app_id=None, app_code=None, timeout=None):
+    def __init__(self, api_key=None, timeout=None):
         """Returns a DestinationWeatherApi instance.
         Args:
-          app_id (str):
-            App Id taken from HERE Developer Portal.
-          app_code (str):
-            App Code taken from HERE Developer Portal.
+          api_key (str):
+            API key taken from HERE Developer Portal.
           timeout (int):
             Timeout limit for requests.
         """
 
-        super(DestinationWeatherApi, self).__init__(app_id, app_code, timeout)
-        self._base_url = "https://weather.api.here.com/weather/1.0/report.json"
+        super(DestinationWeatherApi, self).__init__(api_key, timeout)
+        self._base_url = "https://weather.ls.hereapi.com/weather/1.0/report.json"
 
     def _get(self, data, product):
         url = Utils.build_url(self._base_url, extra_params=data)
@@ -88,8 +86,7 @@ class DestinationWeatherApi(HEREApi):
         """
 
         data = {
-            "app_id": self._app_id,
-            "app_code": self._app_code,
+            "apiKey": self._api_key,
             "product": product.__str__(),
             "oneobservation": one_observation,
             "metric": metric,
@@ -117,8 +114,7 @@ class DestinationWeatherApi(HEREApi):
         """
 
         data = {
-            "app_id": self._app_id,
-            "app_code": self._app_code,
+            "apiKey": self._api_key,
             "product": product.__str__(),
             "oneobservation": one_observation,
             "metric": metric,
@@ -148,8 +144,7 @@ class DestinationWeatherApi(HEREApi):
         """
 
         data = {
-            "app_id": self._app_id,
-            "app_code": self._app_code,
+            "apiKey": self._api_key,
             "product": product.__str__(),
             "oneobservation": one_observation,
             "metric": metric,

--- a/herepy/geocoder_api.py
+++ b/herepy/geocoder_api.py
@@ -13,21 +13,18 @@ class GeocoderApi(HEREApi):
     """A python interface into the HERE Geocoder API"""
 
     def __init__(self,
-                 app_id=None,
-                 app_code=None,
+                 api_key=None,
                  timeout=None):
         """Returns a GeocoderApi instance.
         Args:
-          app_id (str):
-            App Id taken from HERE Developer Portal.
-          app_code (str):
-            App Code taken from HERE Developer Portal.
+          api_key (str):
+            API key taken from HERE Developer Portal.
           timeout (int):
             Timeout limit for requests.
         """
 
-        super(GeocoderApi, self).__init__(app_id, app_code, timeout)
-        self._base_url = 'https://geocoder.cit.api.here.com/6.2/geocode.json'
+        super(GeocoderApi, self).__init__(api_key, timeout)
+        self._base_url = 'https://geocoder.ls.hereapi.com/6.2/geocode.json'
 
     def __get(self, data):
         url = Utils.build_url(self._base_url, extra_params=data)
@@ -51,7 +48,7 @@ class GeocoderApi(HEREApi):
         Raises:
           HEREError"""
 
-        data = {'searchtext': searchtext, 'app_id': self._app_id, 'app_code': self._app_code}
+        data = {'searchtext': searchtext, 'apiKey': self._api_key}
         return self.__get(data)
 
     def address_with_boundingbox(self, searchtext, top_left, bottom_right):
@@ -70,8 +67,7 @@ class GeocoderApi(HEREApi):
 
         data = {'searchtext': searchtext,
                 'mapview': str.format('{0},{1};{2},{3}', top_left[0], top_left[1], bottom_right[0], bottom_right[1]),
-                'app_id': self._app_id,
-                'app_code': self._app_code}
+                'apiKey': self._api_key}
         return self.__get(data)
 
     def address_with_details(self,
@@ -98,8 +94,7 @@ class GeocoderApi(HEREApi):
                 'street': street,
                 'city': city,
                 'country': country,
-                'app_id': self._app_id,
-                'app_code': self._app_code}
+                'apiKey': self._api_key}
         return self.__get(data)
 
     def street_intersection(self,
@@ -118,6 +113,5 @@ class GeocoderApi(HEREApi):
 
         data = {'street': street,
                 'city': city,
-                'app_id': self._app_id,
-                'app_code': self._app_code}
+                'apiKey': self._api_key}
         return self.__get(data)

--- a/herepy/geocoder_autocomplete_api.py
+++ b/herepy/geocoder_autocomplete_api.py
@@ -13,21 +13,18 @@ class GeocoderAutoCompleteApi(HEREApi):
     """A python interface into the HERE Geocoder Auto Complete API"""
 
     def __init__(self,
-                 app_id=None,
-                 app_code=None,
+                 api_key=None,
                  timeout=None):
         """Returns a GeocoderAutoCompleteApi instance.
         Args:
-          app_id (str):
-            App Id taken from HERE Developer Portal.
-          app_code (str):
-            App Code taken from HERE Developer Portal.
+          api_key (str):
+            API key taken from HERE Developer Portal.
           timeout (int):
             Timeout limit for requests.
         """
 
-        super(GeocoderAutoCompleteApi, self).__init__(app_id, app_code, timeout)
-        self._base_url = 'https://autocomplete.geocoder.cit.api.here.com/6.2/suggest.json'
+        super(GeocoderAutoCompleteApi, self).__init__(api_key, timeout)
+        self._base_url = 'http://autocomplete.geocoder.ls.hereapi.com/6.2/suggest.json'
 
     def __get(self, data):
         url = Utils.build_url(self._base_url, extra_params=data)
@@ -52,8 +49,7 @@ class GeocoderAutoCompleteApi(HEREApi):
 
         data = {'query': query,
                 'prox': str.format('{0},{1},{2}', prox[0], prox[1], radius),
-                'app_id': self._app_id,
-                'app_code': self._app_code}
+                'apikey': self._api_key}
         return self.__get(data)
 
     def limit_results_byaddress(self, query, country_code):
@@ -70,8 +66,7 @@ class GeocoderAutoCompleteApi(HEREApi):
 
         data = {'query': query,
                 'country': country_code,
-                'app_id': self._app_id,
-                'app_code': self._app_code}
+                'apikey': self._api_key}
         return self.__get(data)
 
     def highlighting_matches(self, query, begin_highlight, end_highlight):
@@ -91,6 +86,5 @@ class GeocoderAutoCompleteApi(HEREApi):
         data = {'query': query,
                 'beginHighlight': begin_highlight,
                 'endHighlight': end_highlight,
-                'app_id': self._app_id,
-                'app_code': self._app_code}
+                'apikey': self._api_key}
         return self.__get(data)

--- a/herepy/geocoder_reverse_api.py
+++ b/herepy/geocoder_reverse_api.py
@@ -13,21 +13,18 @@ class GeocoderReverseApi(HEREApi):
     """A python interface into the HERE Geocoder Reverse API"""
 
     def __init__(self,
-                 app_id=None,
-                 app_code=None,
+                 api_key=None,
                  timeout=None):
         """Returns a GeocoderApi instance.
         Args:
-          app_id (str):
-            App Id taken from HERE Developer Portal.
-          app_code (str):
-            App Code taken from HERE Developer Portal.
+          api_key (str):
+            API key taken from HERE Developer Portal.
           timeout (int):
             Timeout limit for requests.
         """
 
-        super(GeocoderReverseApi, self).__init__(app_id, app_code, timeout)
-        self._base_url = 'https://reverse.geocoder.api.here.com/6.2/reversegeocode.json'
+        super(GeocoderReverseApi, self).__init__(api_key, timeout)
+        self._base_url = 'https://reverse.geocoder.ls.hereapi.com/6.2/reversegeocode.json'
 
     def __get(self, data):
         url = Utils.build_url(self._base_url, extra_params=data)
@@ -59,7 +56,6 @@ class GeocoderReverseApi(HEREApi):
                 'mode': 'retrieveAddresses',
                 'maxresults': max_results,
                 'gen': gen,
-                'app_id': self._app_id,
-                'app_code': self._app_code}
+                'apiKey': self._api_key}
         return self.__get(data)
 

--- a/herepy/here_api.py
+++ b/herepy/here_api.py
@@ -4,34 +4,29 @@ class HEREApi(object):
     """ Base class from which all wrappers inherit."""
 
     def __init__(self,
-                 app_id=None,
-                 app_code=None,
+                 api_key=None,
                  timeout=None):
         """Returns a Api instance.
         Args:
           app_id (str):
             App Id taken from HERE Developer Portal.
-          app_code (str):
-            App Code taken from HERE Developer Portal.
+          api_key (str):
+            API key taken from HERE Developer Portal.
           timeout (int):
             Timeout limit for requests.
         """
 
-        self.__set_credentials(app_id, app_code)
+        self.__set_credentials(api_key)
         if timeout:
             self._timeout = timeout
         else:
             self._timeout = 20
 
     def __set_credentials(self,
-                          app_id,
-                          app_code):
+                          api_key):
         """Setter for credentials.
         Args:
-          app_id (str):
-            App Id taken from HERE Developer Portal.
-          app_code (str):
-            App Code taken from HERE Developer Portal.
+          api_key (str):
+            API key taken from HERE Developer Portal.
         """
-        self._app_id = app_id
-        self._app_code = app_code
+        self._api_key = api_key

--- a/herepy/places_api.py
+++ b/herepy/places_api.py
@@ -17,21 +17,18 @@ class PlacesApi(HEREApi):
     """A python interface into the HERE Places (Search) API"""
 
     def __init__(self,
-                 app_id=None,
-                 app_code=None,
+                 api_key=None,
                  timeout=None):
         """Returns a PlacesApi instance.
         Args:
-          app_id (str):
-            App Id taken from HERE Developer Portal.
-          app_code (str):
-            App Code taken from HERE Developer Portal.
+          api_key (str):
+            API key taken from HERE Developer Portal.
           timeout (int):
             Timeout limit for requests.
         """
 
-        super(PlacesApi, self).__init__(app_id, app_code, timeout)
-        self._base_url = 'https://places.cit.api.here.com/places/v1/'
+        super(PlacesApi, self).__init__(api_key, timeout)
+        self._base_url = 'https://places.ls.hereapi.com/places/v1/'
 
     def __get(self, data, path, headers=None):
         url = Utils.build_url(self._base_url + path, extra_params=data)
@@ -77,8 +74,7 @@ class PlacesApi(HEREApi):
 
         data = {'at': str.format('{0},{1}', coordinates[0], coordinates[1]),
                 'q':  query,
-                'app_id': self._app_id,
-                'app_code': self._app_code}
+                'apikey': self._api_key}
         return self.__get(data, 'discover/search')
 
     def places_at(self, coordinates):
@@ -92,8 +88,7 @@ class PlacesApi(HEREApi):
           HEREError"""
 
         data = {'at': str.format('{0},{1}', coordinates[0], coordinates[1]),
-                'app_id': self._app_id,
-                'app_code': self._app_code}
+                'apikey': self._api_key}
         return self.__get(data, 'discover/explore')
 
     @classmethod
@@ -121,8 +116,7 @@ class PlacesApi(HEREApi):
 
         data = {'at': str.format('{0},{1}', coordinates[0], coordinates[1]),
                 'cat': self.__prepare_category_values(categories),
-                'app_id': self._app_id,
-                'app_code': self._app_code}
+                'apikey': self._api_key}
         return self.__get(data, 'discover/explore')
 
     def nearby_places(self, coordinates):
@@ -136,8 +130,7 @@ class PlacesApi(HEREApi):
           HEREError"""
 
         data = {'at': str.format('{0},{1}', coordinates[0], coordinates[1]),
-                'app_id': self._app_id,
-                'app_code': self._app_code}
+                'apikey': self._api_key}
         return self.__get(data, 'discover/here')
 
     def search_suggestions(self, coordinates, query):
@@ -154,8 +147,7 @@ class PlacesApi(HEREApi):
 
         data = {'at': str.format('{0},{1}', coordinates[0], coordinates[1]),
                 'q': query,
-                'app_id': self._app_id,
-                'app_code': self._app_code}
+                'apikey': self._api_key}
         return self.__get_suggestions(data)
 
     def place_categories(self, coordinates):
@@ -169,8 +161,7 @@ class PlacesApi(HEREApi):
           HEREError"""
 
         data = {'at': str.format('{0},{1}', coordinates[0], coordinates[1]),
-                'app_id': self._app_id,
-                'app_code': self._app_code}
+                'apikey': self._api_key}
         return self.__get_categories(data)
 
     def places_at_boundingbox(self, coordinates_a, coordinates_b):
@@ -186,8 +177,7 @@ class PlacesApi(HEREApi):
           HEREError"""
 
         data = {'in': str.format('{0},{1},{2},{3}', coordinates_a[0], coordinates_a[1], coordinates_b[0], coordinates_b[1]),
-                'app_id': self._app_id,
-                'app_code': self._app_code}
+                'apikey': self._api_key}
         return self.__get(data, 'discover/explore')
 
     def places_with_language(self, coordinates, language):
@@ -203,7 +193,6 @@ class PlacesApi(HEREApi):
           HEREError"""
 
         data = {'at': str.format('{0},{1}', coordinates[0], coordinates[1]),
-                'app_id': self._app_id,
-                'app_code': self._app_code}
+                'apikey': self._api_key}
         headers = {'accept-language': language}
         return self.__get(data, 'discover/explore')

--- a/herepy/public_transit_api.py
+++ b/herepy/public_transit_api.py
@@ -17,21 +17,18 @@ class PublicTransitApi(HEREApi):
     """A python interface into the HERE Public Transit API"""
 
     def __init__(self,
-                 app_id=None,
-                 app_code=None,
+                 api_key=None,
                  timeout=None):
         """Returns a PublicTransitApi instance.
         Args:
-          app_id (str):
-            App Id taken from HERE Developer Portal.
-          app_code (str):
-            App Code taken from HERE Developer Portal.
+          api_key (str):
+            API key taken from HERE Developer Portal.
           timeout (int):
             Timeout limit for requests.
         """
 
-        super(PublicTransitApi, self).__init__(app_id, app_code, timeout)
-        self._base_url = 'https://cit.transit.api.here.com/v3/'
+        super(PublicTransitApi, self).__init__(api_key, timeout)
+        self._base_url = 'https://transit.ls.hereapi.com/v3/'
 
     def __get(self, data, path, json_node):
         url = Utils.build_url(self._base_url + path, extra_params=data)
@@ -70,8 +67,7 @@ class PublicTransitApi(HEREApi):
 
         data = {'center': str.format('{0},{1}', center[0], center[1]),
                 'name':  name,
-                'app_id': self._app_id,
-                'app_code': self._app_code,
+                'apikey': self._api_key,
                 'max': max_count,
                 'method': method.__str__(),
                 'radius': radius}
@@ -94,8 +90,7 @@ class PublicTransitApi(HEREApi):
 
         data = {'center': str.format('{0},{1}', center[0], center[1]),
                 'radius': radius,
-                'app_id': self._app_id,
-                'app_code': self._app_code,
+                'apikey': self._api_key,
                 'max': max_count}
         return self.__get(data, 'stations/by_geocoord.json', 'Stations')
 
@@ -122,8 +117,7 @@ class PublicTransitApi(HEREApi):
 
         data = {'stnIds': self.__prepare_station_ids(ids),
                 'lang': lang,
-                'app_id': self._app_id,
-                'app_code': self._app_code}
+                'apikey': self._api_key}
         return self.__get(data, 'stations/by_ids.json', 'Stations')
 
     def find_transit_coverage_in_cities(self, center, political_view, radius):
@@ -144,8 +138,7 @@ class PublicTransitApi(HEREApi):
         data = {'center': str.format('{0},{1}', center[0], center[1]),
                 'politicalview': political_view,
                 'radius': radius,
-                'app_id': self._app_id,
-                'app_code': self._app_code}
+                'apikey': self._api_key,}
         return self.__get(data, 'coverage/city.json', 'Coverage')
 
     def next_nearby_departures_of_station(self, station_id, time, lang='en'):
@@ -166,8 +159,7 @@ class PublicTransitApi(HEREApi):
         data = {'lang': lang,
                 'stnId': station_id,
                 'time': time,
-                'app_id': self._app_id,
-                'app_code': self._app_code}
+                'apikey': self._api_key}
         return self.__get(data, 'board.json', 'NextDepartures')
 
     def next_departures_from_location(self,
@@ -197,8 +189,7 @@ class PublicTransitApi(HEREApi):
         data = {'lang': lang,
                 'center': str.format('{0},{1}', center[0], center[1]),
                 'time': time,
-                'app_id': self._app_id,
-                'app_code': self._app_code,
+                'apikey': self._api_key,
                 'max': max,
                 'maxStn': max_station}
         return self.__get(data, 'multiboard/by_geocoord.json', 'MultiNextDepartures')
@@ -229,8 +220,7 @@ class PublicTransitApi(HEREApi):
 
         data = {'lang': lang,
                 'time': time,
-                'app_id': self._app_id,
-                'app_code': self._app_code,
+                'apikey': self._api_key,
                 'max': max,
                 'maxStn': max_station,
                 'stnIds': self.__prepare_station_ids(station_ids)}
@@ -260,8 +250,7 @@ class PublicTransitApi(HEREApi):
         data = {'dep': str.format('{0},{1}', departure[0], departure[1]),
                 'arr': str.format('{0},{1}', arrival[0], arrival[1]),
                 'time': time,
-                'app_id': self._app_id,
-                'app_code': self._app_code,
+                'apikey': self._api_key,
                 'routing': routing_type.__str__()}
         return self.__get(data, 'route.json', 'Connections')
 
@@ -292,8 +281,7 @@ class PublicTransitApi(HEREApi):
         data = {'dep': str.format('{0},{1}', departure[0], departure[1]),
                 'arr': str.format('{0},{1}', arrival[0], arrival[1]),
                 'time': time,
-                'app_id': self._app_id,
-                'app_code': self._app_code,
+                'apikey': self._api_key,
                 'arrival': 1 if show_arrival_times == True else 0,
                 'routing': routing_type.__str__()}
         return self.__get(data, 'route.json', 'Connections')
@@ -325,8 +313,7 @@ class PublicTransitApi(HEREApi):
         data = {'dep': str.format('{0},{1}', departure[0], departure[1]),
                 'arr': str.format('{0},{1}', arrival[0], arrival[1]),
                 'time': time,
-                'app_id': self._app_id,
-                'app_code': self._app_code,
+                'apikey': self._api_key,
                 'routing': routing_type.__str__(),
                 'graph': graph}
         return self.__get(data, 'route.json', 'Connections')
@@ -357,8 +344,7 @@ class PublicTransitApi(HEREApi):
         """
 
         data = {'name': city_name,
-                'app_id': self._app_id,
-                'app_code': self._app_code,
+                'apikey': self._api_key,
                 'max': max,
                 'details': details,
                 'politicalview': political_view,
@@ -381,8 +367,7 @@ class PublicTransitApi(HEREApi):
         """
         data = {'details': details,
                 'center': str.format('{0},{1}', center[0], center[1]),
-                'app_id': self._app_id,
-                'app_code': self._app_code}
+                'apikey': self._api_key}
         return self.__get(data, 'coverage/nearby.json', 'LocalCoverage')
 
     def route_excluding_changes_transfers(self,
@@ -412,8 +397,7 @@ class PublicTransitApi(HEREApi):
         data = {'dep': str.format('{0},{1}', departure[0], departure[1]),
                 'arr': str.format('{0},{1}', arrival[0], arrival[1]),
                 'time': time,
-                'app_id': self._app_id,
-                'app_code': self._app_code,
+                'apikey': self._api_key,
                 'routing': routing_type.__str__(),
                 'changes': changes}
         return self.__get(data, 'route.json', 'Connections')

--- a/herepy/rme_api.py
+++ b/herepy/rme_api.py
@@ -13,21 +13,18 @@ class RmeApi(HEREApi):
     """A python interface into the RME API"""
 
     def __init__(self,
-                 app_id=None,
-                 app_code=None,
+                 api_key=None,
                  timeout=None):
         """Returns a RmeApi instance.
         Args:
-          app_id (str):
-            App Id taken from HERE Developer Portal.
-          app_code (str):
-            App Code taken from HERE Developer Portal.
+          api_key (str):
+            API key taken from HERE Developer Portal.
           timeout (int):
             Timeout limit for requests.
         """
 
-        super(RmeApi, self).__init__(app_id, app_code, timeout)
-        self._base_url = 'https://rme.api.here.com/2/matchroute.json'
+        super(RmeApi, self).__init__(api_key, timeout)
+        self._base_url = 'https://m.fleet.ls.hereapi.com/2/matchroute.json'
 
     def __get(self, data):
         url = Utils.build_url(self._base_url, extra_params=data)
@@ -64,9 +61,8 @@ class RmeApi(HEREApi):
           HEREError"""
 
         data = {'file': Utils.get_zipped_base64(gpx_file_content),
-                'route_mode': route_mode,
+                'routemode': route_mode,
                 'attributes': ','.join(pde_layers),
-                'app_id': self._app_id,
-                'app_code': self._app_code}
+                'apikey': self._api_key}
         return self.__get(data)
 

--- a/herepy/routing_api.py
+++ b/herepy/routing_api.py
@@ -14,24 +14,21 @@ from herepy.here_enum import RouteMode, MatrixSummaryAttribute
 class RoutingApi(HEREApi):
     """A python interface into the HERE Routing API"""
 
-    URL_CALCULATE_ROUTE = 'https://route.cit.api.here.com/routing/7.2/calculateroute.json'
-    URL_CALCULATE_MATRIX = 'https://matrix.route.api.here.com/routing/7.2/calculatematrix.json'
+    URL_CALCULATE_ROUTE = 'https://route.ls.hereapi.com/routing/7.2/calculateroute.json'
+    URL_CALCULATE_MATRIX = 'https://matrix.route.ls.hereapi.com/routing/7.2/calculatematrix.json'
 
     def __init__(self,
-                 app_id=None,
-                 app_code=None,
+                 api_key=None,
                  timeout=None):
         """Returns a RoutingApi instance.
         Args:
-          app_id (str):
-            App Id taken from HERE Developer Portal.
-          app_code (str):
-            App Code taken from HERE Developer Portal.
+          api_key (str):
+            API key taken from HERE Developer Portal.
           timeout (int):
             Timeout limit for requests.
         """
 
-        super(RoutingApi, self).__init__(app_id, app_code, timeout)
+        super(RoutingApi, self).__init__(api_key, timeout)
 
     def __get(self, base_url, data, response_cls):
         url = Utils.build_url(base_url, extra_params=data)
@@ -58,8 +55,7 @@ class RoutingApi(HEREApi):
         data = {'waypoint0': self.__array_to_waypoint(waypoint_a),
                 'waypoint1': self.__array_to_waypoint(waypoint_b),
                 'mode': self.__prepare_mode_values(modes),
-                'app_id': self._app_id,
-                'app_code': self._app_code}
+                'apikey': self._api_key}
         if departure is not None and arrival is not None:
             raise HEREError("Specify either departure or arrival, not both.")
         if departure is not None:
@@ -315,8 +311,7 @@ class RoutingApi(HEREApi):
         """
 
         data = {
-            'app_id': self._app_id,
-            'app_code': self._app_code,
+            'apikey': self._api_key,
             'departure': departure,
             'mode': self.__prepare_mode_values(modes),
             'summaryAttributes': ','.join([attribute.__str__() for attribute in summary_attributes])

--- a/tests/test_destination_weather_api.py
+++ b/tests/test_destination_weather_api.py
@@ -11,20 +11,19 @@ from herepy.here_enum import WeatherProductType
 class DestinationWeatherApiTest(unittest.TestCase):
 
     def setUp(self):
-        api = herepy.DestinationWeatherApi('app_id', 'app_code')
+        api = herepy.DestinationWeatherApi('api_key')
         self._api = api
 
     def test_initiation(self):
         self.assertIsInstance(self._api, herepy.DestinationWeatherApi)
-        self.assertEqual(self._api._app_id, 'app_id')
-        self.assertEqual(self._api._app_code, 'app_code')
-        self.assertEqual(self._api._base_url, 'https://weather.api.here.com/weather/1.0/report.json')
+        self.assertEqual(self._api._api_key, 'api_key')
+        self.assertEqual(self._api._base_url, 'https://weather.ls.hereapi.com/weather/1.0/report.json')
 
     @responses.activate
     def test_invalid_request_is_thrown(self):
         with open('testdata/models/destination_weather_error_invalid_request.json', 'r') as f:
             expectedResponse = f.read()
-        responses.add(responses.GET, 'https://weather.api.here.com/weather/1.0/report.json',
+        responses.add(responses.GET, 'https://weather.ls.hereapi.com/weather/1.0/report.json',
                   expectedResponse, status=200)
         product = herepy.WeatherProductType.forecast_7days
         name = "Berlin"
@@ -35,7 +34,7 @@ class DestinationWeatherApiTest(unittest.TestCase):
     def test_unauthorized_is_thrown(self):
         with open('testdata/models/destination_weather_error_unauthorized.json', 'r') as f:
             expectedResponse = f.read()
-        responses.add(responses.GET, 'https://weather.api.here.com/weather/1.0/report.json',
+        responses.add(responses.GET, 'https://weather.ls.hereapi.com/weather/1.0/report.json',
                   expectedResponse, status=200)
         product = herepy.WeatherProductType.forecast_7days
         name = "Berlin"
@@ -46,7 +45,7 @@ class DestinationWeatherApiTest(unittest.TestCase):
     def test_weather_for_location_name(self):
         with open('testdata/models/destination_weather_forecasts.json', 'r') as f:
             expectedResponse = f.read()
-        responses.add(responses.GET, 'https://weather.api.here.com/weather/1.0/report.json',
+        responses.add(responses.GET, 'https://weather.ls.hereapi.com/weather/1.0/report.json',
                   expectedResponse, status=200)
         product = herepy.WeatherProductType.forecast_7days
         name = "Berlin"
@@ -58,7 +57,7 @@ class DestinationWeatherApiTest(unittest.TestCase):
     def test_weather_for_coordinates(self):
         with open('testdata/models/destination_weather_forecasts.json', 'r') as f:
             expectedResponse = f.read()
-        responses.add(responses.GET, 'https://weather.api.here.com/weather/1.0/report.json',
+        responses.add(responses.GET, 'https://weather.ls.hereapi.com/weather/1.0/report.json',
                   expectedResponse, status=200)
         product = herepy.WeatherProductType.forecast_7days
         latitude = 52.51784
@@ -71,7 +70,7 @@ class DestinationWeatherApiTest(unittest.TestCase):
     def test_weather_for_zip_code(self):
         with open('testdata/models/destination_weather_forecasts.json', 'r') as f:
             expectedResponse = f.read()
-        responses.add(responses.GET, 'https://weather.api.here.com/weather/1.0/report.json',
+        responses.add(responses.GET, 'https://weather.ls.hereapi.com/weather/1.0/report.json',
                   expectedResponse, status=200)
         product = herepy.WeatherProductType.forecast_7days
         zip_code = "10025"
@@ -83,7 +82,7 @@ class DestinationWeatherApiTest(unittest.TestCase):
     def test_weather_product_type_alerts(self):
         with open('testdata/models/destination_weather_alerts.json', 'r') as f:
             expectedResponse = f.read()
-        responses.add(responses.GET, 'https://weather.api.here.com/weather/1.0/report.json',
+        responses.add(responses.GET, 'https://weather.ls.hereapi.com/weather/1.0/report.json',
                   expectedResponse, status=200)
         product = herepy.WeatherProductType.alerts
         zip_code = "10025"
@@ -95,7 +94,7 @@ class DestinationWeatherApiTest(unittest.TestCase):
     def test_weather_product_type_forecast_7days(self):
         with open('testdata/models/destination_weather_forecasts.json', 'r') as f:
             expectedResponse = f.read()
-        responses.add(responses.GET, 'https://weather.api.here.com/weather/1.0/report.json',
+        responses.add(responses.GET, 'https://weather.ls.hereapi.com/weather/1.0/report.json',
                   expectedResponse, status=200)
         product = herepy.WeatherProductType.forecast_7days
         zip_code = "10025"
@@ -107,7 +106,7 @@ class DestinationWeatherApiTest(unittest.TestCase):
     def test_weather_product_type_forecast_7days_simple(self):
         with open('testdata/models/destination_weather_forecasts_simple.json', 'r') as f:
             expectedResponse = f.read()
-        responses.add(responses.GET, 'https://weather.api.here.com/weather/1.0/report.json',
+        responses.add(responses.GET, 'https://weather.ls.hereapi.com/weather/1.0/report.json',
                   expectedResponse, status=200)
         product = herepy.WeatherProductType.forecast_7days_simple
         zip_code = "10025"
@@ -119,7 +118,7 @@ class DestinationWeatherApiTest(unittest.TestCase):
     def test_weather_product_type_forecast_astronomy(self):
         with open('testdata/models/destination_weather_forecasts_astronomy.json', 'r') as f:
             expectedResponse = f.read()
-        responses.add(responses.GET, 'https://weather.api.here.com/weather/1.0/report.json',
+        responses.add(responses.GET, 'https://weather.ls.hereapi.com/weather/1.0/report.json',
                   expectedResponse, status=200)
         product = herepy.WeatherProductType.forecast_astronomy
         zip_code = "10025"
@@ -131,7 +130,7 @@ class DestinationWeatherApiTest(unittest.TestCase):
     def test_weather_product_type_forecast_hourly(self):
         with open('testdata/models/destination_weather_forecasts_hourly.json', 'r') as f:
             expectedResponse = f.read()
-        responses.add(responses.GET, 'https://weather.api.here.com/weather/1.0/report.json',
+        responses.add(responses.GET, 'https://weather.ls.hereapi.com/weather/1.0/report.json',
                   expectedResponse, status=200)
         product = herepy.WeatherProductType.forecast_hourly
         zip_code = "10025"
@@ -143,7 +142,7 @@ class DestinationWeatherApiTest(unittest.TestCase):
     def test_weather_product_type_nws_alerts(self):
         with open('testdata/models/destination_weather_forecasts_nsw_alerts.json', 'r') as f:
             expectedResponse = f.read()
-        responses.add(responses.GET, 'https://weather.api.here.com/weather/1.0/report.json',
+        responses.add(responses.GET, 'https://weather.ls.hereapi.com/weather/1.0/report.json',
                   expectedResponse, status=200)
         product = herepy.WeatherProductType.nws_alerts
         zip_code = "10025"

--- a/tests/test_geocoder_api.py
+++ b/tests/test_geocoder_api.py
@@ -10,20 +10,19 @@ import herepy
 class GeocoderApiTest(unittest.TestCase):
 
     def setUp(self):
-        api = herepy.GeocoderApi('app_id', 'app_code')
+        api = herepy.GeocoderApi('api_key')
         self._api = api
 
     def test_initiation(self):
         self.assertIsInstance(self._api, herepy.GeocoderApi)
-        self.assertEqual(self._api._app_id, 'app_id')
-        self.assertEqual(self._api._app_code, 'app_code')
-        self.assertEqual(self._api._base_url, 'https://geocoder.cit.api.here.com/6.2/geocode.json')
+        self.assertEqual(self._api._api_key, 'api_key')
+        self.assertEqual(self._api._base_url, 'https://geocoder.ls.hereapi.com/6.2/geocode.json')
 
     @responses.activate
     def test_freeform_whensucceed(self):
         with open('testdata/models/geocoder.json', 'r') as f:
             expectedResponse = f.read()
-        responses.add(responses.GET, 'https://geocoder.cit.api.here.com/6.2/geocode.json',
+        responses.add(responses.GET, 'https://geocoder.ls.hereapi.com/6.2/geocode.json',
                   expectedResponse, status=200)
         response = self._api.free_form('200 S Mathilda Sunnyvale CA')
         self.assertTrue(response)
@@ -33,7 +32,7 @@ class GeocoderApiTest(unittest.TestCase):
     def test_freeform_whenerroroccured(self):
         with open('testdata/models/geocoder_error.json', 'r') as f:
             expectedResponse = f.read()
-        responses.add(responses.GET, 'https://geocoder.cit.api.here.com/6.2/geocode.json',
+        responses.add(responses.GET, 'https://geocoder.ls.hereapi.com/6.2/geocode.json',
                   expectedResponse, status=200)
         with self.assertRaises(herepy.HEREError):
             self._api.free_form('')
@@ -42,7 +41,7 @@ class GeocoderApiTest(unittest.TestCase):
     def test_address_withboundingbox_whensucceed(self):
         with open('testdata/models/geocoder.json', 'r') as f:
             expectedResponse = f.read()
-        responses.add(responses.GET, 'https://geocoder.cit.api.here.com/6.2/geocode.json',
+        responses.add(responses.GET, 'https://geocoder.ls.hereapi.com/6.2/geocode.json',
                   expectedResponse, status=200)
         response = self._api.address_with_boundingbox('200 S Mathilda Sunnyvale CA', [42.3952, -71.1056], [42.3312, -71.0228])
         self.assertTrue(response)
@@ -52,7 +51,7 @@ class GeocoderApiTest(unittest.TestCase):
     def test_address_withboundingbox_whenerroroccured(self):
         with open('testdata/models/geocoder_error.json', 'r') as f:
             expectedResponse = f.read()
-        responses.add(responses.GET, 'https://geocoder.cit.api.here.com/6.2/geocode.json',
+        responses.add(responses.GET, 'https://geocoder.ls.hereapi.com/6.2/geocode.json',
                   expectedResponse, status=200)
         with self.assertRaises(herepy.HEREError):
             self._api.address_with_boundingbox('', [-42.3952, -71.1056], [-42.3312, -71.0228])
@@ -61,7 +60,7 @@ class GeocoderApiTest(unittest.TestCase):
     def test_addresswithdetails_whensucceed(self):
         with open('testdata/models/geocoder.json', 'r') as f:
             expectedResponse = f.read()
-        responses.add(responses.GET, 'https://geocoder.cit.api.here.com/6.2/geocode.json',
+        responses.add(responses.GET, 'https://geocoder.ls.hereapi.com/6.2/geocode.json',
                   expectedResponse, status=200)
         response = self._api.address_with_details(34, 'Barbaros', 'Istanbul', 'Turkey')
         self.assertTrue(response)
@@ -71,7 +70,7 @@ class GeocoderApiTest(unittest.TestCase):
     def test_addresswithdetails_whenerroroccured(self):
         with open('testdata/models/geocoder_error.json', 'r') as f:
             expectedResponse = f.read()
-        responses.add(responses.GET, 'https://geocoder.cit.api.here.com/6.2/geocode.json',
+        responses.add(responses.GET, 'https://geocoder.ls.hereapi.com/6.2/geocode.json',
                   expectedResponse, status=200)
         with self.assertRaises(herepy.HEREError):
             self._api.address_with_details(-34, '', '', '')
@@ -80,7 +79,7 @@ class GeocoderApiTest(unittest.TestCase):
     def test_streetintersection_whensucceed(self):
         with open('testdata/models/geocoder.json', 'r') as f:
             expectedResponse = f.read()
-        responses.add(responses.GET, 'https://geocoder.cit.api.here.com/6.2/geocode.json',
+        responses.add(responses.GET, 'https://geocoder.ls.hereapi.com/6.2/geocode.json',
                   expectedResponse, status=200)
         response = self._api.street_intersection('Barbaros', 'Istanbul')
         self.assertTrue(response)
@@ -90,7 +89,7 @@ class GeocoderApiTest(unittest.TestCase):
     def test_streetintersection__whenerroroccured(self):
         with open('testdata/models/geocoder_error.json', 'r') as f:
             expectedResponse = f.read()
-        responses.add(responses.GET, 'https://geocoder.cit.api.here.com/6.2/geocode.json',
+        responses.add(responses.GET, 'https://geocoder.ls.hereapi.com/6.2/geocode.json',
                   expectedResponse, status=200)
         with self.assertRaises(herepy.HEREError):
             self._api.street_intersection('', '')

--- a/tests/test_geocoder_autocomplete_api.py
+++ b/tests/test_geocoder_autocomplete_api.py
@@ -10,20 +10,19 @@ import herepy
 class GeocoderAutoCompleteApiTest(unittest.TestCase):
 
     def setUp(self):
-        api = herepy.GeocoderAutoCompleteApi('app_id', 'app_code')
+        api = herepy.GeocoderAutoCompleteApi('api_key')
         self._api = api
 
     def test_initiation(self):
         self.assertIsInstance(self._api, herepy.GeocoderAutoCompleteApi)
-        self.assertEqual(self._api._app_id, 'app_id')
-        self.assertEqual(self._api._app_code, 'app_code')
-        self.assertEqual(self._api._base_url, 'https://autocomplete.geocoder.cit.api.here.com/6.2/suggest.json')
+        self.assertEqual(self._api._api_key, 'api_key')
+        self.assertEqual(self._api._base_url, 'http://autocomplete.geocoder.ls.hereapi.com/6.2/suggest.json')
 
     @responses.activate
     def test_addresssuggestion_whensucceed(self):
         with open('testdata/models/geocoder_autocomplete.json', 'r') as f:
             expectedResponse = f.read()
-        responses.add(responses.GET, 'https://autocomplete.geocoder.cit.api.here.com/6.2/suggest.json',
+        responses.add(responses.GET, 'http://autocomplete.geocoder.ls.hereapi.com/6.2/suggest.json',
                   expectedResponse, status=200)
         response = self._api.address_suggestion('High', [51.5035, -0.1616], 100)
         self.assertTrue(response)
@@ -33,7 +32,7 @@ class GeocoderAutoCompleteApiTest(unittest.TestCase):
     def test_addresssuggestion_whenerroroccured(self):
         with open('testdata/models/geocoder_autocomplete_error.json', 'r') as f:
             expectedResponse = f.read()
-        responses.add(responses.GET, 'https://autocomplete.geocoder.cit.api.here.com/6.2/suggest.json',
+        responses.add(responses.GET, 'http://autocomplete.geocoder.ls.hereapi.com/6.2/suggest.json',
                   expectedResponse, status=200)
         with self.assertRaises(herepy.HEREError):
             self._api.address_suggestion('', [51.5035, -0.1616], 100)
@@ -42,7 +41,7 @@ class GeocoderAutoCompleteApiTest(unittest.TestCase):
     def test_limitresultsbyaddress_whensucceed(self):
         with open('testdata/models/geocoder_autocomplete.json', 'r') as f:
             expectedResponse = f.read()
-        responses.add(responses.GET, 'https://autocomplete.geocoder.cit.api.here.com/6.2/suggest.json',
+        responses.add(responses.GET, 'http://autocomplete.geocoder.ls.hereapi.com/6.2/suggest.json',
                   expectedResponse, status=200)
         response = self._api.limit_results_byaddress('Nis', 'USA')
         self.assertTrue(response)
@@ -52,7 +51,7 @@ class GeocoderAutoCompleteApiTest(unittest.TestCase):
     def test_limitresultsbyaddress_whenerroroccured(self):
         with open('testdata/models/geocoder_autocomplete_error.json', 'r') as f:
             expectedResponse = f.read()
-        responses.add(responses.GET, 'https://autocomplete.geocoder.cit.api.here.com/6.2/suggest.json',
+        responses.add(responses.GET, 'http://autocomplete.geocoder.ls.hereapi.com/6.2/suggest.json',
                   expectedResponse, status=200)
         with self.assertRaises(herepy.HEREError):
             self._api.limit_results_byaddress('', '')
@@ -61,7 +60,7 @@ class GeocoderAutoCompleteApiTest(unittest.TestCase):
     def test_highlightingmatches_whensucceed(self):
         with open('testdata/models/geocoder_autocomplete.json', 'r') as f:
             expectedResponse = f.read()
-        responses.add(responses.GET, 'https://autocomplete.geocoder.cit.api.here.com/6.2/suggest.json',
+        responses.add(responses.GET, 'http://autocomplete.geocoder.ls.hereapi.com/6.2/suggest.json',
                   expectedResponse, status=200)
         response = self._api.highlighting_matches('Wacker Chic', '**', '**')
         self.assertTrue(response)
@@ -71,7 +70,7 @@ class GeocoderAutoCompleteApiTest(unittest.TestCase):
     def test_highlightingmatches_whenerroroccured(self):
         with open('testdata/models/geocoder_autocomplete_error.json', 'r') as f:
             expectedResponse = f.read()
-        responses.add(responses.GET, 'https://autocomplete.geocoder.cit.api.here.com/6.2/suggest.json',
+        responses.add(responses.GET, 'http://autocomplete.geocoder.ls.hereapi.com/6.2/suggest.json',
                   expectedResponse, status=200)
         with self.assertRaises(herepy.HEREError):
             self._api.highlighting_matches('', '**', '**')

--- a/tests/test_geocoder_reverse_api.py
+++ b/tests/test_geocoder_reverse_api.py
@@ -10,20 +10,19 @@ import herepy
 class GeocoderReverseApiTest(unittest.TestCase):
 
     def setUp(self):
-        api = herepy.GeocoderReverseApi('app_id', 'app_code')
+        api = herepy.GeocoderReverseApi('api_key')
         self._api = api
 
     def test_initiation(self):
         self.assertIsInstance(self._api, herepy.GeocoderReverseApi)
-        self.assertEqual(self._api._app_id, 'app_id')
-        self.assertEqual(self._api._app_code, 'app_code')
-        self.assertEqual(self._api._base_url, 'https://reverse.geocoder.api.here.com/6.2/reversegeocode.json')
+        self.assertEqual(self._api._api_key, 'api_key')
+        self.assertEqual(self._api._base_url, 'https://reverse.geocoder.ls.hereapi.com/6.2/reversegeocode.json')
 
     @responses.activate
     def test_retrieve_addresses_whensucceed(self):
         with open('testdata/models/geocoder_reverse.json', 'r') as f:
             expectedResponse = f.read()
-        responses.add(responses.GET, 'https://reverse.geocoder.api.here.com/6.2/reversegeocode.json',
+        responses.add(responses.GET, 'https://reverse.geocoder.ls.hereapi.com/6.2/reversegeocode.json',
                   expectedResponse, status=200)
         response = self._api.retrieve_addresses([41.8842,-87.6388], 250)
         self.assertTrue(response)
@@ -33,7 +32,7 @@ class GeocoderReverseApiTest(unittest.TestCase):
     def test_retrieve_addresses_whenerroroccured(self):
         with open('testdata/models/geocoder_error.json', 'r') as f:
             expectedResponse = f.read()
-        responses.add(responses.GET, 'https://reverse.geocoder.api.here.com/6.2/reversegeocode.json',
+        responses.add(responses.GET, 'https://reverse.geocoder.ls.hereapi.com/6.2/reversegeocode.json',
                   expectedResponse, status=200)
         with self.assertRaises(herepy.HEREError):
             self._api.retrieve_addresses([None,None],0)

--- a/tests/test_places_api.py
+++ b/tests/test_places_api.py
@@ -11,20 +11,19 @@ import herepy
 class PlacesApiTest(unittest.TestCase):
 
     def setUp(self):
-        api = herepy.PlacesApi('app_id', 'app_code')
+        api = herepy.PlacesApi('api_key')
         self._api = api
 
     def test_initiation(self):
         self.assertIsInstance(self._api, herepy.PlacesApi)
-        self.assertEqual(self._api._app_id, 'app_id')
-        self.assertEqual(self._api._app_code, 'app_code')
-        self.assertEqual(self._api._base_url, 'https://places.cit.api.here.com/places/v1/')
+        self.assertEqual(self._api._api_key, 'api_key')
+        self.assertEqual(self._api._base_url, 'https://places.ls.hereapi.com/places/v1/')
 
     @responses.activate
     def test_onebox_search_whensucceed(self):
         with open('testdata/models/places_api.json', 'r') as f:
             expectedResponse = f.read()
-        responses.add(responses.GET, 'https://places.cit.api.here.com/places/v1/discover/search',
+        responses.add(responses.GET, 'https://places.ls.hereapi.com/places/v1/discover/search',
                   expectedResponse, status=200)
         response = self._api.onebox_search([37.7905, -122.4107], 'restaurant')
         self.assertTrue(response)
@@ -34,7 +33,7 @@ class PlacesApiTest(unittest.TestCase):
     def test_onebox_search_whenerroroccured(self):
         with open('testdata/models/places_api_error.json', 'r') as f:
             expectedResponse = f.read()
-        responses.add(responses.GET, 'https://places.cit.api.here.com/places/v1/discover/search',
+        responses.add(responses.GET, 'https://places.ls.hereapi.com/places/v1/discover/search',
                   expectedResponse, status=200)
         with self.assertRaises(herepy.HEREError):
             self._api.onebox_search([37.7905, -122.4107], '')
@@ -43,7 +42,7 @@ class PlacesApiTest(unittest.TestCase):
     def test_places_at_whensucceed(self):
         with open('testdata/models/places_api.json', 'r') as f:
             expectedResponse = f.read()
-        responses.add(responses.GET, 'https://places.cit.api.here.com/places/v1/discover/explore',
+        responses.add(responses.GET, 'https://places.ls.hereapi.com/places/v1/discover/explore',
                   expectedResponse, status=200)
         response = self._api.places_at([37.7905, -122.4107])
         self.assertTrue(response)
@@ -53,7 +52,7 @@ class PlacesApiTest(unittest.TestCase):
     def test_places_at_whenerroroccured(self):
         with open('testdata/models/places_api_error.json', 'r') as f:
             expectedResponse = f.read()
-        responses.add(responses.GET, 'https://places.cit.api.here.com/places/v1/discover/explore',
+        responses.add(responses.GET, 'https://places.ls.hereapi.com/places/v1/discover/explore',
                   expectedResponse, status=200)
         with self.assertRaises(herepy.HEREError):
             self._api.places_at([-9999.0, -9999.0])
@@ -62,7 +61,7 @@ class PlacesApiTest(unittest.TestCase):
     def test_category_places_at_whensucceed(self):
         with open('testdata/models/places_api.json', 'r') as f:
             expectedResponse = f.read()
-        responses.add(responses.GET, 'https://places.cit.api.here.com/places/v1/discover/explore',
+        responses.add(responses.GET, 'https://places.ls.hereapi.com/places/v1/discover/explore',
                   expectedResponse, status=200)
         response = self._api.category_places_at([37.7905, -122.4107], [herepy.PlacesCategory.eat_drink])
         self.assertTrue(response)
@@ -72,7 +71,7 @@ class PlacesApiTest(unittest.TestCase):
     def test_category_places_at_whenerroroccured(self):
         with open('testdata/models/places_api_error.json', 'r') as f:
             expectedResponse = f.read()
-        responses.add(responses.GET, 'https://places.cit.api.here.com/places/v1/discover/explore',
+        responses.add(responses.GET, 'https://places.ls.hereapi.com/places/v1/discover/explore',
                   expectedResponse, status=200)
         with self.assertRaises(herepy.HEREError):
             self._api.category_places_at([-9999.0, -9999.0], [herepy.PlacesCategory.eat_drink])
@@ -86,7 +85,7 @@ class PlacesApiTest(unittest.TestCase):
     def test_nearby_places_whensucceed(self):
         with open('testdata/models/places_api.json', 'r') as f:
             expectedResponse = f.read()
-        responses.add(responses.GET, 'https://places.cit.api.here.com/places/v1/discover/here',
+        responses.add(responses.GET, 'https://places.ls.hereapi.com/places/v1/discover/here',
                   expectedResponse, status=200)
         response = self._api.nearby_places([37.7905, -122.4107])
         self.assertTrue(response)
@@ -96,7 +95,7 @@ class PlacesApiTest(unittest.TestCase):
     def test_nearby_places_whenerroroccured(self):
         with open('testdata/models/places_api_error.json', 'r') as f:
             expectedResponse = f.read()
-        responses.add(responses.GET, 'https://places.cit.api.here.com/places/v1/discover/here',
+        responses.add(responses.GET, 'https://places.ls.hereapi.com/places/v1/discover/here',
                   expectedResponse, status=200)
         with self.assertRaises(herepy.HEREError):
             self._api.nearby_places([-9999.0, -9999.0])
@@ -105,7 +104,7 @@ class PlacesApiTest(unittest.TestCase):
     def test_search_suggestions_whensucceed(self):
         with io.open('testdata/models/places_api_suggestions.json', 'r', encoding='utf-8') as f:
             expectedResponse = f.read()
-        responses.add(responses.GET, 'https://places.cit.api.here.com/places/v1/suggest',
+        responses.add(responses.GET, 'https://places.ls.hereapi.com/places/v1/suggest',
                   expectedResponse, status=200)
         response = self._api.search_suggestions([52.5159, 13.3777], 'berlin')
         self.assertTrue(response)
@@ -115,7 +114,7 @@ class PlacesApiTest(unittest.TestCase):
     def test_search_suggestions_whenerroroccured(self):
         with open('testdata/models/places_api_error.json', 'r') as f:
             expectedResponse = f.read()
-        responses.add(responses.GET, 'https://places.cit.api.here.com/places/v1/suggest',
+        responses.add(responses.GET, 'https://places.ls.hereapi.com/places/v1/suggest',
                   expectedResponse, status=200)
         with self.assertRaises(herepy.HEREError):
             self._api.search_suggestions([-9999.0, -9999.0], '')
@@ -124,7 +123,7 @@ class PlacesApiTest(unittest.TestCase):
     def test_place_categories_whensucceed(self):
         with open('testdata/models/places_api_categories.json', 'r') as f:
             expectedResponse = f.read()
-        responses.add(responses.GET, 'https://places.cit.api.here.com/places/v1/categories/places',
+        responses.add(responses.GET, 'https://places.ls.hereapi.com/places/v1/categories/places',
                   expectedResponse, status=200)
         response = self._api.place_categories([52.5159, 13.3777])
         self.assertTrue(response)
@@ -134,7 +133,7 @@ class PlacesApiTest(unittest.TestCase):
     def test_place_categories_whenerroroccured(self):
         with open('testdata/models/places_api_error.json', 'r') as f:
             expectedResponse = f.read()
-        responses.add(responses.GET, 'https://places.cit.api.here.com/places/v1/categories/places',
+        responses.add(responses.GET, 'https://places.ls.hereapi.com/places/v1/categories/places',
                   expectedResponse, status=200)
         with self.assertRaises(herepy.HEREError):
             self._api.place_categories([-9999.0, -9999.0])
@@ -143,7 +142,7 @@ class PlacesApiTest(unittest.TestCase):
     def test_places_at_boundingbox_whensucceed(self):
         with open('testdata/models/places_api.json', 'r') as f:
             expectedResponse = f.read()
-        responses.add(responses.GET, 'https://places.cit.api.here.com/places/v1/discover/explore',
+        responses.add(responses.GET, 'https://places.ls.hereapi.com/places/v1/discover/explore',
                   expectedResponse, status=200)
         response = self._api.places_at_boundingbox([-122.408, 37.793], [-122.4070, 37.7942])
         self.assertTrue(response)
@@ -153,7 +152,7 @@ class PlacesApiTest(unittest.TestCase):
     def test_places_at_boundingbox_whenerroroccured(self):
         with open('testdata/models/places_api_error.json', 'r') as f:
             expectedResponse = f.read()
-        responses.add(responses.GET, 'https://places.cit.api.here.com/places/v1/discover/explore',
+        responses.add(responses.GET, 'https://places.ls.hereapi.com/places/v1/discover/explore',
                   expectedResponse, status=200)
         with self.assertRaises(herepy.HEREError):
             self._api.places_at_boundingbox([-9999.0, -9999.0], [-9999.0, -9999.0])
@@ -162,7 +161,7 @@ class PlacesApiTest(unittest.TestCase):
     def test_places_with_language_whensucceed(self):
         with open('testdata/models/places_api.json', 'r') as f:
             expectedResponse = f.read()
-        responses.add(responses.GET, 'https://places.cit.api.here.com/places/v1/discover/explore',
+        responses.add(responses.GET, 'https://places.ls.hereapi.com/places/v1/discover/explore',
                   expectedResponse, status=200)
         response = self._api.places_with_language([48.8580, 2.2945], 'en-US')
         self.assertTrue(response)
@@ -172,7 +171,7 @@ class PlacesApiTest(unittest.TestCase):
     def test_places_with_language_whenerroroccured(self):
         with open('testdata/models/places_api_error.json', 'r') as f:
             expectedResponse = f.read()
-        responses.add(responses.GET, 'https://places.cit.api.here.com/places/v1/discover/explore',
+        responses.add(responses.GET, 'https://places.ls.hereapi.com/places/v1/discover/explore',
                   expectedResponse, status=200)
         with self.assertRaises(herepy.HEREError):
             self._api.places_with_language([-9999.0, -9999.0], '')

--- a/tests/test_publictransit_api.py
+++ b/tests/test_publictransit_api.py
@@ -11,20 +11,19 @@ import herepy
 class PublicTransitApiTest(unittest.TestCase):
 
     def setUp(self):
-        api = herepy.PublicTransitApi('app_id', 'app_code')
+        api = herepy.PublicTransitApi('api_key')
         self._api = api
 
     def test_initiation(self):
         self.assertIsInstance(self._api, herepy.PublicTransitApi)
-        self.assertEqual(self._api._app_id, 'app_id')
-        self.assertEqual(self._api._app_code, 'app_code')
-        self.assertEqual(self._api._base_url, 'https://cit.transit.api.here.com/v3/')
+        self.assertEqual(self._api._api_key, 'api_key')
+        self.assertEqual(self._api._base_url, 'https://transit.ls.hereapi.com/v3/')
 
     @responses.activate
     def test_find_stations_by_name_whensucceed(self):
         with open('testdata/models/public_transit_api.json', 'r') as f:
             expectedResponse = f.read()
-        responses.add(responses.GET, 'https://cit.transit.api.here.com/v3/stations/by_name.json',
+        responses.add(responses.GET, 'https://transit.ls.hereapi.com/v3/stations/by_name.json',
                   expectedResponse, status=200)
         response = self._api.find_stations_by_name([40.7505, -73.9910],
                                                    'union',
@@ -38,7 +37,7 @@ class PublicTransitApiTest(unittest.TestCase):
     def test_find_stations_by_name_whenerroroccured(self):
         with open('testdata/models/public_transit_api_error.json', 'r') as f:
             expectedResponse = f.read()
-        responses.add(responses.GET, 'https://cit.transit.api.here.com/v3/stations/by_name.json',
+        responses.add(responses.GET, 'https://transit.ls.hereapi.com/v3/stations/by_name.json',
                   expectedResponse, status=200)
         with self.assertRaises(herepy.HEREError):
             self._api.find_stations_by_name([40.7505, -73.9910], '')
@@ -47,7 +46,7 @@ class PublicTransitApiTest(unittest.TestCase):
     def test_find_stations_nearby_whensucceed(self):
         with io.open('testdata/models/public_transit_api_nearby.json', 'r', encoding='utf-8') as f:
             expectedResponse = f.read()
-        responses.add(responses.GET, 'https://cit.transit.api.here.com/v3/stations/by_geocoord.json',
+        responses.add(responses.GET, 'https://transit.ls.hereapi.com/v3/stations/by_geocoord.json',
                   expectedResponse, status=200)
         response = self._api.find_stations_nearby([55.7541, 37.6200], 350, 3)
         self.assertTrue(response)
@@ -57,7 +56,7 @@ class PublicTransitApiTest(unittest.TestCase):
     def test_find_stations_nearby_whenerroroccured(self):
         with open('testdata/models/public_transit_api_error.json', 'r') as f:
             expectedResponse = f.read()
-        responses.add(responses.GET, 'https://cit.transit.api.here.com/v3/stations/by_geocoord.json',
+        responses.add(responses.GET, 'https://transit.ls.hereapi.com/v3/stations/by_geocoord.json',
                   expectedResponse, status=200)
         with self.assertRaises(herepy.HEREError):
             self._api.find_stations_nearby([-9999, -9999])
@@ -66,7 +65,7 @@ class PublicTransitApiTest(unittest.TestCase):
     def test_find_stations_by_id_whensucceed(self):
         with io.open('testdata/models/public_transit_api_by_id.json', 'r', encoding='utf-8') as f:
             expectedResponse = f.read()
-        responses.add(responses.GET, 'https://cit.transit.api.here.com/v3/stations/by_ids.json',
+        responses.add(responses.GET, 'https://transit.ls.hereapi.com/v3/stations/by_ids.json',
                   expectedResponse, status=200)
         response = self._api.find_stations_by_id([720390022, 720390000], 'en')
         self.assertTrue(response)
@@ -76,7 +75,7 @@ class PublicTransitApiTest(unittest.TestCase):
     def test_find_stations_by_id_whenerroroccured(self):
         with open('testdata/models/public_transit_api_error.json', 'r') as f:
             expectedResponse = f.read()
-        responses.add(responses.GET, 'https://cit.transit.api.here.com/v3/stations/by_ids.json',
+        responses.add(responses.GET, 'https://transit.ls.hereapi.com/v3/stations/by_ids.json',
                   expectedResponse, status=200)
         with self.assertRaises(herepy.HEREError):
             self._api.find_stations_by_id([-99999], 'tr')
@@ -85,7 +84,7 @@ class PublicTransitApiTest(unittest.TestCase):
     def test_find_transit_coverage_in_cities_whensucceed(self):
         with io.open('testdata/models/public_transit_api_coverage_cities.json', 'r', encoding='utf-8') as f:
             expectedResponse = f.read()
-        responses.add(responses.GET, 'https://cit.transit.api.here.com/v3/coverage/city.json',
+        responses.add(responses.GET, 'https://transit.ls.hereapi.com/v3/coverage/city.json',
                   expectedResponse, status=200)
         response = self._api.find_transit_coverage_in_cities([42.3580, -71.0636], 'USA', 50000)
         self.assertTrue(response)
@@ -95,7 +94,7 @@ class PublicTransitApiTest(unittest.TestCase):
     def test_find_transit_coverage_in_cities_whenerroroccured(self):
         with open('testdata/models/public_transit_api_error.json', 'r') as f:
             expectedResponse = f.read()
-        responses.add(responses.GET, 'https://cit.transit.api.here.com/v3/coverage/city.json',
+        responses.add(responses.GET, 'https://transit.ls.hereapi.com/v3/coverage/city.json',
                   expectedResponse, status=200)
         with self.assertRaises(herepy.HEREError):
             self._api.find_transit_coverage_in_cities([-9999, -9999], '', 100)
@@ -104,7 +103,7 @@ class PublicTransitApiTest(unittest.TestCase):
     def test_next_nearby_departures_of_station_whensucceed(self):
         with io.open('testdata/models/public_transit_api_next_nearby_departures.json', 'r', encoding='utf-8') as f:
             expectedResponse = f.read()
-        responses.add(responses.GET, 'https://cit.transit.api.here.com/v3/board.json',
+        responses.add(responses.GET, 'https://transit.ls.hereapi.com/v3/board.json',
                   expectedResponse, status=200)
         response = self._api.next_nearby_departures_of_station(402000653, '2017-11-21T11:10:00')
         self.assertTrue(response)
@@ -114,7 +113,7 @@ class PublicTransitApiTest(unittest.TestCase):
     def test_next_nearby_departures_of_station_whenerroroccured(self):
         with open('testdata/models/public_transit_api_error.json', 'r') as f:
             expectedResponse = f.read()
-        responses.add(responses.GET, 'https://cit.transit.api.here.com/v3/board.json',
+        responses.add(responses.GET, 'https://transit.ls.hereapi.com/v3/board.json',
                   expectedResponse, status=200)
         with self.assertRaises(herepy.HEREError):
             self._api.next_nearby_departures_of_station(-1, '')
@@ -123,7 +122,7 @@ class PublicTransitApiTest(unittest.TestCase):
     def test_next_departures_from_location_whensucceed(self):
         with io.open('testdata/models/public_transit_api_next_departures_location.json', 'r', encoding='utf-8') as f:
             expectedResponse = f.read()
-        responses.add(responses.GET, 'https://cit.transit.api.here.com/v3/multiboard/by_geocoord.json',
+        responses.add(responses.GET, 'https://transit.ls.hereapi.com/v3/multiboard/by_geocoord.json',
                   expectedResponse, status=200)
         response = self._api.next_departures_from_location([51.4477, -0.1669], '2017-11-21T07:30:00')
         self.assertTrue(response)
@@ -133,7 +132,7 @@ class PublicTransitApiTest(unittest.TestCase):
     def test_next_departures_from_location_whenerroroccured(self):
         with open('testdata/models/public_transit_api_error.json', 'r') as f:
             expectedResponse = f.read()
-        responses.add(responses.GET, 'https://cit.transit.api.here.com/v3/multiboard/by_geocoord.json',
+        responses.add(responses.GET, 'https://transit.ls.hereapi.com/v3/multiboard/by_geocoord.json',
                   expectedResponse, status=200)
         with self.assertRaises(herepy.HEREError):
             self._api.next_departures_from_location([-9999, -9999], '')
@@ -142,7 +141,7 @@ class PublicTransitApiTest(unittest.TestCase):
     def test_next_departures_for_stations_whensucceed(self):
         with io.open('testdata/models/public_transit_api_next_departures_for_stations.json', 'r', encoding='utf-8') as f:
             expectedResponse = f.read()
-        responses.add(responses.GET, 'https://cit.transit.api.here.com/v3/multiboard/by_stn_ids.json',
+        responses.add(responses.GET, 'https://transit.ls.hereapi.com/v3/multiboard/by_stn_ids.json',
                   expectedResponse, status=200)
         response = self._api.next_departures_for_stations([402000656, 402000653, 402061786], '2017-11-22T07:30:00')
         self.assertTrue(response)
@@ -152,7 +151,7 @@ class PublicTransitApiTest(unittest.TestCase):
     def test_next_departures_for_stations_whenerroroccured(self):
         with open('testdata/models/public_transit_api_error.json', 'r') as f:
             expectedResponse = f.read()
-        responses.add(responses.GET, 'https://cit.transit.api.here.com/v3/multiboard/by_stn_ids.json',
+        responses.add(responses.GET, 'https://transit.ls.hereapi.com/v3/multiboard/by_stn_ids.json',
                   expectedResponse, status=200)
         with self.assertRaises(herepy.HEREError):
             self._api.next_departures_for_stations([-99999, -99999, -99999], '')
@@ -161,7 +160,7 @@ class PublicTransitApiTest(unittest.TestCase):
     def test_calculate_route_whensucceed(self):
         with io.open('testdata/models/public_transit_calculate_route.json', 'r', encoding='utf-8') as f:
             expectedResponse = f.read()
-        responses.add(responses.GET, 'https://cit.transit.api.here.com/v3/route.json',
+        responses.add(responses.GET, 'https://transit.ls.hereapi.com/v3/route.json',
                   expectedResponse, status=200)
         response = self._api.calculate_route([41.9773, -87.9019], [41.8961, -87.6552], '2017-11-22T07:30:00', herepy.PublicTransitRoutingType.time_tabled)
         self.assertTrue(response)
@@ -171,7 +170,7 @@ class PublicTransitApiTest(unittest.TestCase):
     def test_calculate_route_whenerroroccured(self):
         with open('testdata/models/public_transit_api_error.json', 'r') as f:
             expectedResponse = f.read()
-        responses.add(responses.GET, 'https://cit.transit.api.here.com/v3/route.json',
+        responses.add(responses.GET, 'https://transit.ls.hereapi.com/v3/route.json',
                   expectedResponse, status=200)
         with self.assertRaises(herepy.HEREError):
             self._api.calculate_route([-9999, -9999], [-9999, -9999], '2017-11-22T07:30:00', herepy.PublicTransitRoutingType.time_tabled)
@@ -180,7 +179,7 @@ class PublicTransitApiTest(unittest.TestCase):
     def test_calculate_route_time_whensucceed(self):
         with io.open('testdata/models/public_transit_api_calculate_route_time.json', 'r', encoding='utf-8') as f:
             expectedResponse = f.read()
-        responses.add(responses.GET, 'https://cit.transit.api.here.com/v3/route.json',
+        responses.add(responses.GET, 'https://transit.ls.hereapi.com/v3/route.json',
                   expectedResponse, status=200)
         response = self._api.calculate_route_time([41.9773, -87.9019],
                                                   [41.8961, -87.6552],
@@ -194,7 +193,7 @@ class PublicTransitApiTest(unittest.TestCase):
     def test_calculate_route_time_whenerroroccured(self):
         with open('testdata/models/public_transit_api_error.json', 'r') as f:
             expectedResponse = f.read()
-        responses.add(responses.GET, 'https://cit.transit.api.here.com/v3/route.json',
+        responses.add(responses.GET, 'https://transit.ls.hereapi.com/v3/route.json',
                   expectedResponse, status=200)
         with self.assertRaises(herepy.HEREError):
             self._api.calculate_route_time([-9999, -9999],
@@ -207,7 +206,7 @@ class PublicTransitApiTest(unittest.TestCase):
     def test_transit_route_shows_line_graph_whensucceed(self):
         with io.open('testdata/models/public_transit_api_calculate_route_time.json', 'r', encoding='utf-8') as f:
             expectedResponse = f.read()
-        responses.add(responses.GET, 'https://cit.transit.api.here.com/v3/route.json',
+        responses.add(responses.GET, 'https://transit.ls.hereapi.com/v3/route.json',
                   expectedResponse, status=200)
         response = self._api.transit_route_shows_line_graph([41.9773, -87.9019],
                                                             [41.8961, -87.6552],
@@ -219,7 +218,7 @@ class PublicTransitApiTest(unittest.TestCase):
     def test_transit_route_shows_line_graph_whenerroroccured(self):
         with open('testdata/models/public_transit_api_error.json', 'r') as f:
             expectedResponse = f.read()
-        responses.add(responses.GET, 'https://cit.transit.api.here.com/v3/route.json',
+        responses.add(responses.GET, 'https://transit.ls.hereapi.com/v3/route.json',
                   expectedResponse, status=200)
         with self.assertRaises(herepy.HEREError):
             self._api.transit_route_shows_line_graph([-9999, -9999],
@@ -230,7 +229,7 @@ class PublicTransitApiTest(unittest.TestCase):
     def test_coverage_witin_a_city_whensucceed(self):
         with io.open('testdata/models/public_transit_city_coverage.json', 'r', encoding='utf-8') as f:
             expectedResponse = f.read()
-        responses.add(responses.GET, 'https://cit.transit.api.here.com/v3/coverage/search.json',
+        responses.add(responses.GET, 'https://transit.ls.hereapi.com/v3/coverage/search.json',
                   expectedResponse, status=200)
         response = self._api.coverage_witin_a_city('chicago', 10, 1, 0, 'en')
         self.assertTrue(response)
@@ -240,7 +239,7 @@ class PublicTransitApiTest(unittest.TestCase):
     def test_coverage_witin_a_city_whenerroroccured(self):
         with open('testdata/models/public_transit_api_error.json', 'r') as f:
             expectedResponse = f.read()
-        responses.add(responses.GET, 'https://cit.transit.api.here.com/v3/coverage/search.json',
+        responses.add(responses.GET, 'https://transit.ls.hereapi.com/v3/coverage/search.json',
                   expectedResponse, status=200)
         with self.assertRaises(herepy.HEREError):
             self._api.coverage_witin_a_city('', 10, 1, 0)
@@ -249,7 +248,7 @@ class PublicTransitApiTest(unittest.TestCase):
     def test_coverage_nearby_whensucceed(self):
         with io.open('testdata/models/public_transit_api_nearby_coverage.json', 'r', encoding='utf-8') as f:
             expectedResponse = f.read()
-        responses.add(responses.GET, 'https://cit.transit.api.here.com/v3/coverage/nearby.json',
+        responses.add(responses.GET, 'https://transit.ls.hereapi.com/v3/coverage/nearby.json',
                   expectedResponse, status=200)
         response = self._api.coverage_nearby(0, [52.5160, 13.3778])
         self.assertTrue(response)
@@ -259,7 +258,7 @@ class PublicTransitApiTest(unittest.TestCase):
     def test_coverage_nearby_whenerroroccured(self):
         with open('testdata/models/public_transit_api_error.json', 'r') as f:
             expectedResponse = f.read()
-        responses.add(responses.GET, 'https://cit.transit.api.here.com/v3/coverage/nearby.json',
+        responses.add(responses.GET, 'https://transit.ls.hereapi.com/v3/coverage/nearby.json',
                   expectedResponse, status=200)
         with self.assertRaises(herepy.HEREError):
             self._api.coverage_nearby(0, [-9999, -9999])
@@ -268,7 +267,7 @@ class PublicTransitApiTest(unittest.TestCase):
     def test_route_excluding_changes_transfers_whensucceed(self):
         with io.open('testdata/models/public_transit_api_router_exclude_changes.json', 'r', encoding='utf-8') as f:
             expectedResponse = f.read()
-        responses.add(responses.GET, 'https://cit.transit.api.here.com/v3/route.json',
+        responses.add(responses.GET, 'https://transit.ls.hereapi.com/v3/route.json',
                   expectedResponse, status=200)
         response = self._api.route_excluding_changes_transfers([40.752470, -73.97800],
                                                                [40.750501, -73.99351],
@@ -280,7 +279,7 @@ class PublicTransitApiTest(unittest.TestCase):
     def test_croute_excluding_changes_transfers_whenerroroccured(self):
         with open('testdata/models/public_transit_api_error.json', 'r') as f:
             expectedResponse = f.read()
-        responses.add(responses.GET, 'https://cit.transit.api.here.com/v3/route.json',
+        responses.add(responses.GET, 'https://transit.ls.hereapi.com/v3/route.json',
                   expectedResponse, status=200)
         with self.assertRaises(herepy.HEREError):
             self._api.route_excluding_changes_transfers([-9998, -9998],

--- a/tests/test_rme_api.py
+++ b/tests/test_rme_api.py
@@ -11,20 +11,19 @@ import io
 class RmeApiTest(unittest.TestCase):
 
     def setUp(self):
-        api = herepy.RmeApi('app_id', 'app_code')
+        api = herepy.RmeApi('api_key')
         self._api = api
 
     def test_initiation(self):
         self.assertIsInstance(self._api, herepy.RmeApi)
-        self.assertEqual(self._api._app_id, 'app_id')
-        self.assertEqual(self._api._app_code, 'app_code')
-        self.assertEqual(self._api._base_url, 'https://rme.api.here.com/2/matchroute.json')
+        self.assertEqual(self._api._api_key, 'api_key')
+        self.assertEqual(self._api._base_url, 'https://m.fleet.ls.hereapi.com/2/matchroute.json')
 
     @responses.activate
     def test_match_route_whensucceed(self):
         with io.open('testdata/models/rme_match_route_api.json', 'r') as f:
             expectedResponse = f.read()
-        responses.add(responses.GET, 'https://rme.api.here.com/2/matchroute.json',
+        responses.add(responses.GET, 'https://m.fleet.ls.hereapi.com/2/matchroute.json',
                   expectedResponse, status=200)
         with io.open('testdata/routes/sample.gpx', encoding='utf-8') as gpx_file:
             gpx_content = gpx_file.read()
@@ -36,7 +35,7 @@ class RmeApiTest(unittest.TestCase):
     def test_match_route_whenerroroccured(self):
         with open('testdata/models/geocoder_error.json', 'r') as f:
             expectedResponse = f.read()
-        responses.add(responses.GET, 'https://rme.api.here.com/2/matchroute.json',
+        responses.add(responses.GET, 'https://m.fleet.ls.hereapi.com/2/matchroute.json',
                   expectedResponse, status=200)
         with self.assertRaises(herepy.HEREError):
             self._api.match_route('')

--- a/tests/test_routing_api.py
+++ b/tests/test_routing_api.py
@@ -11,19 +11,18 @@ import herepy
 class RoutingApiTest(unittest.TestCase):
 
     def setUp(self):
-        api = herepy.RoutingApi('app_id', 'app_code')
+        api = herepy.RoutingApi('api_key')
         self._api = api
 
     def test_initiation(self):
         self.assertIsInstance(self._api, herepy.RoutingApi)
-        self.assertEqual(self._api._app_id, 'app_id')
-        self.assertEqual(self._api._app_code, 'app_code')
+        self.assertEqual(self._api._api_key, 'api_key')
 
     @responses.activate
     def test_bicycleroute_withdefaultmodes_whensucceed(self):
         with codecs.open('testdata/models/routing_bicycle.json', mode='r', encoding='utf-8') as f:
             expectedResponse = f.read()
-        responses.add(responses.GET, 'https://route.cit.api.here.com/routing/7.2/calculateroute.json',
+        responses.add(responses.GET, 'https://route.ls.hereapi.com/routing/7.2/calculateroute.json',
                   expectedResponse, status=200)
         response = self._api.bicycle_route([41.9798, -87.8801], [41.9043, -87.9216])
         self.assertTrue(response)
@@ -33,7 +32,7 @@ class RoutingApiTest(unittest.TestCase):
     def test_bicycleroute_route_short(self):
         with codecs.open('testdata/models/routing_bicycle.json', mode='r', encoding='utf-8') as f:
             expectedResponse = f.read()
-        responses.add(responses.GET, 'https://route.cit.api.here.com/routing/7.2/calculateroute.json',
+        responses.add(responses.GET, 'https://route.ls.hereapi.com/routing/7.2/calculateroute.json',
                   expectedResponse, status=200)
         response = self._api.bicycle_route([41.9798, -87.8801], [41.9043, -87.9216])
         expected_short_route = (
@@ -47,7 +46,7 @@ class RoutingApiTest(unittest.TestCase):
     def test_carroute_whensucceed(self):
         with codecs.open('testdata/models/routing.json', mode='r', encoding='utf-8') as f:
             expectedResponse = f.read()
-        responses.add(responses.GET, 'https://route.cit.api.here.com/routing/7.2/calculateroute.json',
+        responses.add(responses.GET, 'https://route.ls.hereapi.com/routing/7.2/calculateroute.json',
                   expectedResponse, status=200)
         response = self._api.car_route([11.0, 12.0], [22.0, 23.0], [herepy.RouteMode.car, herepy.RouteMode.fastest])
         self.assertTrue(response)
@@ -57,7 +56,7 @@ class RoutingApiTest(unittest.TestCase):
     def test_carroute_route_short(self):
         with codecs.open('testdata/models/routing_car_route_short.json', mode='r', encoding='utf-8') as f:
             expectedResponse = f.read()
-        responses.add(responses.GET, 'https://route.cit.api.here.com/routing/7.2/calculateroute.json',
+        responses.add(responses.GET, 'https://route.ls.hereapi.com/routing/7.2/calculateroute.json',
                   expectedResponse, status=200)
         response = self._api.car_route([38.9, -77.04833], [39.0, -77.1])
         expected_short_route = (
@@ -70,7 +69,7 @@ class RoutingApiTest(unittest.TestCase):
     def test_carroute_withdefaultmodes_whensucceed(self):
         with codecs.open('testdata/models/routing.json', mode='r', encoding='utf-8') as f:
             expectedResponse = f.read()
-        responses.add(responses.GET, 'https://route.cit.api.here.com/routing/7.2/calculateroute.json',
+        responses.add(responses.GET, 'https://route.ls.hereapi.com/routing/7.2/calculateroute.json',
                   expectedResponse, status=200)
         response = self._api.car_route([11.0, 12.0], [22.0, 23.0])
         self.assertTrue(response)
@@ -80,7 +79,7 @@ class RoutingApiTest(unittest.TestCase):
     def test_carroute_when_error_invalid_input_data_occured(self):
         with open('testdata/models/routing_error_invalid_input_data.json', 'r') as f:
             expectedResponse = f.read()
-        responses.add(responses.GET, 'https://route.cit.api.here.com/routing/7.2/calculateroute.json',
+        responses.add(responses.GET, 'https://route.ls.hereapi.com/routing/7.2/calculateroute.json',
                   expectedResponse, status=200)
         with self.assertRaises(herepy.InvalidInputDataError):
             self._api.car_route([11.0, 12.0], [22.0, 23.0], [herepy.RouteMode.pedestrian, herepy.RouteMode.fastest])
@@ -89,9 +88,9 @@ class RoutingApiTest(unittest.TestCase):
     def test_carroute_when_error_invalid_credentials_occured(self):
         with open('testdata/models/routing_error_invalid_credentials.json', 'r') as f:
             expectedResponse = f.read()
-        responses.add(responses.GET, 'https://route.cit.api.here.com/routing/7.2/calculateroute.json',
+        responses.add(responses.GET, 'https://route.ls.hereapi.com/routing/7.2/calculateroute.json',
                   expectedResponse, status=200)
-        api = herepy.RoutingApi('wrong_app_id', 'wrong_app_code')
+        api = herepy.RoutingApi('wrong_api_key', 'wrong_app_code')
         with self.assertRaises(herepy.InvalidCredentialsError):
             api.car_route([11.0, 12.0], [22.0, 23.0])
 
@@ -99,7 +98,7 @@ class RoutingApiTest(unittest.TestCase):
     def test_carroute_when_error_no_route_found_occured(self):
         with open('testdata/models/routing_error_no_route_found.json', 'r') as f:
             expectedResponse = f.read()
-        responses.add(responses.GET, 'https://route.cit.api.here.com/routing/7.2/calculateroute.json',
+        responses.add(responses.GET, 'https://route.ls.hereapi.com/routing/7.2/calculateroute.json',
                   expectedResponse, status=200)
         with self.assertRaises(herepy.NoRouteFoundError):
             self._api.car_route([11.0, 12.0], [47.013399, -10.171986])
@@ -108,7 +107,7 @@ class RoutingApiTest(unittest.TestCase):
     def test_pedastrianroute_whensucceed(self):
         with codecs.open('testdata/models/routing_pedestrian.json', mode='r', encoding='utf-8') as f:
             expectedResponse = f.read()
-        responses.add(responses.GET, 'https://route.cit.api.here.com/routing/7.2/calculateroute.json',
+        responses.add(responses.GET, 'https://route.ls.hereapi.com/routing/7.2/calculateroute.json',
                   expectedResponse, status=200)
         response = self._api.pedastrian_route([11.0, 12.0], [22.0, 23.0], [herepy.RouteMode.pedestrian, herepy.RouteMode.fastest])
         self.assertTrue(response)
@@ -118,7 +117,7 @@ class RoutingApiTest(unittest.TestCase):
     def test_pedastrianroute_withdefaultmodes_whensucceed(self):
         with codecs.open('testdata/models/routing_pedestrian.json', mode='r', encoding='utf-8') as f:
             expectedResponse = f.read()
-        responses.add(responses.GET, 'https://route.cit.api.here.com/routing/7.2/calculateroute.json',
+        responses.add(responses.GET, 'https://route.ls.hereapi.com/routing/7.2/calculateroute.json',
                   expectedResponse, status=200)
         response = self._api.pedastrian_route([11.0, 12.0], [22.0, 23.0])
         self.assertTrue(response)
@@ -128,7 +127,7 @@ class RoutingApiTest(unittest.TestCase):
     def test_pedastrianroute_when_error_invalid_input_data_occured(self):
         with open('testdata/models/routing_error_invalid_input_data.json', 'r') as f:
             expectedResponse = f.read()
-        responses.add(responses.GET, 'https://route.cit.api.here.com/routing/7.2/calculateroute.json',
+        responses.add(responses.GET, 'https://route.ls.hereapi.com/routing/7.2/calculateroute.json',
                   expectedResponse, status=200)
         with self.assertRaises(herepy.InvalidInputDataError):
             self._api.pedastrian_route([11.0, 12.0], [22.0, 23.0], [herepy.RouteMode.car, herepy.RouteMode.fastest])
@@ -137,9 +136,9 @@ class RoutingApiTest(unittest.TestCase):
     def test_pedastrianroute_when_error_invalid_credentials_occured(self):
         with open('testdata/models/routing_error_invalid_credentials.json', 'r') as f:
             expectedResponse = f.read()
-        responses.add(responses.GET, 'https://route.cit.api.here.com/routing/7.2/calculateroute.json',
+        responses.add(responses.GET, 'https://route.ls.hereapi.com/routing/7.2/calculateroute.json',
                   expectedResponse, status=200)
-        api = herepy.RoutingApi('wrong_app_id', 'wrong_app_code')
+        api = herepy.RoutingApi('wrong_api_key', 'wrong_app_code')
         with self.assertRaises(herepy.InvalidCredentialsError):
             api.pedastrian_route([11.0, 12.0], [22.0, 23.0])
 
@@ -147,7 +146,7 @@ class RoutingApiTest(unittest.TestCase):
     def test_pedastrianroute_when_error_no_route_found_occured(self):
         with open('testdata/models/routing_error_no_route_found.json', 'r') as f:
             expectedResponse = f.read()
-        responses.add(responses.GET, 'https://route.cit.api.here.com/routing/7.2/calculateroute.json',
+        responses.add(responses.GET, 'https://route.ls.hereapi.com/routing/7.2/calculateroute.json',
                   expectedResponse, status=200)
         with self.assertRaises(herepy.NoRouteFoundError):
             self._api.pedastrian_route([11.0, 12.0], [47.013399, -10.171986])
@@ -156,7 +155,7 @@ class RoutingApiTest(unittest.TestCase):
     def test_pedastrianroute_route_short(self):
         with codecs.open('testdata/models/routing_pedestrian.json', mode='r', encoding='utf-8') as f:
             expectedResponse = f.read()
-        responses.add(responses.GET, 'https://route.cit.api.here.com/routing/7.2/calculateroute.json',
+        responses.add(responses.GET, 'https://route.ls.hereapi.com/routing/7.2/calculateroute.json',
                   expectedResponse, status=200)
         response = self._api.pedastrian_route([11.0, 12.0], [22.0, 23.0], [herepy.RouteMode.pedestrian, herepy.RouteMode.fastest])
         expected_short_route = (
@@ -170,7 +169,7 @@ class RoutingApiTest(unittest.TestCase):
     def test_intermediateroute_whensucceed(self):
         with codecs.open('testdata/models/routing.json', mode='r', encoding='utf-8') as f:
             expectedResponse = f.read()
-        responses.add(responses.GET, 'https://route.cit.api.here.com/routing/7.2/calculateroute.json',
+        responses.add(responses.GET, 'https://route.ls.hereapi.com/routing/7.2/calculateroute.json',
                   expectedResponse, status=200)
         response = self._api.intermediate_route([11.0, 12.0], [15.0, 16.0], [22.0, 23.0], [herepy.RouteMode.car, herepy.RouteMode.fastest])
         self.assertTrue(response)
@@ -180,7 +179,7 @@ class RoutingApiTest(unittest.TestCase):
     def test_intermediateroute_withdefaultmodes_whensucceed(self):
         with codecs.open('testdata/models/routing.json', mode='r', encoding='utf-8') as f:
             expectedResponse = f.read()
-        responses.add(responses.GET, 'https://route.cit.api.here.com/routing/7.2/calculateroute.json',
+        responses.add(responses.GET, 'https://route.ls.hereapi.com/routing/7.2/calculateroute.json',
                   expectedResponse, status=200)
         response = self._api.intermediate_route([11.0, 12.0], [15.0, 16.0], [22.0, 23.0])
         self.assertTrue(response)
@@ -190,7 +189,7 @@ class RoutingApiTest(unittest.TestCase):
     def test_intermediateroute_when_error_invalid_input_data_occured(self):
         with open('testdata/models/routing_error_invalid_input_data.json', 'r') as f:
             expectedResponse = f.read()
-        responses.add(responses.GET, 'https://route.cit.api.here.com/routing/7.2/calculateroute.json',
+        responses.add(responses.GET, 'https://route.ls.hereapi.com/routing/7.2/calculateroute.json',
                   expectedResponse, status=200)
         with self.assertRaises(herepy.InvalidInputDataError):
             self._api.intermediate_route([11.0, 12.0], [15.0, 16.0], [22.0, 23.0], [herepy.RouteMode.car, herepy.RouteMode.fastest])
@@ -199,9 +198,9 @@ class RoutingApiTest(unittest.TestCase):
     def test_intermediateroute_when_error_invalid_credentials_occured(self):
         with open('testdata/models/routing_error_invalid_credentials.json', 'r') as f:
             expectedResponse = f.read()
-        responses.add(responses.GET, 'https://route.cit.api.here.com/routing/7.2/calculateroute.json',
+        responses.add(responses.GET, 'https://route.ls.hereapi.com/routing/7.2/calculateroute.json',
                   expectedResponse, status=200)
-        api = herepy.RoutingApi('wrong_app_id', 'wrong_app_code')
+        api = herepy.RoutingApi('wrong_api_key', 'wrong_app_code')
         with self.assertRaises(herepy.InvalidCredentialsError):
             api.intermediate_route([11.0, 12.0], [15.0, 16.0], [22.0, 23.0])
 
@@ -209,7 +208,7 @@ class RoutingApiTest(unittest.TestCase):
     def test_intermediateroute_when_error_no_route_found_occured(self):
         with open('testdata/models/routing_error_no_route_found.json', 'r') as f:
             expectedResponse = f.read()
-        responses.add(responses.GET, 'https://route.cit.api.here.com/routing/7.2/calculateroute.json',
+        responses.add(responses.GET, 'https://route.ls.hereapi.com/routing/7.2/calculateroute.json',
                   expectedResponse, status=200)
         with self.assertRaises(herepy.NoRouteFoundError):
             self._api.intermediate_route([11.0, 12.0], [47.013399, -10.171986], [22.0, 23.0])
@@ -218,7 +217,7 @@ class RoutingApiTest(unittest.TestCase):
     def test_publictransport_whensucceed(self):
         with codecs.open('testdata/models/routing_public.json', mode='r', encoding='utf-8') as f:
             expectedResponse = f.read()
-        responses.add(responses.GET, 'https://route.cit.api.here.com/routing/7.2/calculateroute.json',
+        responses.add(responses.GET, 'https://route.ls.hereapi.com/routing/7.2/calculateroute.json',
                   expectedResponse, status=200)
         response = self._api.public_transport([11.0, 12.0],
                                               [15.0, 16.0],
@@ -231,7 +230,7 @@ class RoutingApiTest(unittest.TestCase):
     def test_publictransport_route_short(self):
         with codecs.open('testdata/models/routing_public.json', mode='r', encoding='utf-8') as f:
             expectedResponse = f.read()
-        responses.add(responses.GET, 'https://route.cit.api.here.com/routing/7.2/calculateroute.json',
+        responses.add(responses.GET, 'https://route.ls.hereapi.com/routing/7.2/calculateroute.json',
                   expectedResponse, status=200)
         response = self._api.public_transport([11.0, 12.0],
                                               [15.0, 16.0],
@@ -245,7 +244,7 @@ class RoutingApiTest(unittest.TestCase):
     def test_publictransport_withdefaultmodes_whensucceed(self):
         with codecs.open('testdata/models/routing_public.json', mode='r', encoding='utf-8') as f:
             expectedResponse = f.read()
-        responses.add(responses.GET, 'https://route.cit.api.here.com/routing/7.2/calculateroute.json',
+        responses.add(responses.GET, 'https://route.ls.hereapi.com/routing/7.2/calculateroute.json',
                   expectedResponse, status=200)
         response = self._api.public_transport([11.0, 12.0],
                                               [15.0, 16.0],
@@ -257,7 +256,7 @@ class RoutingApiTest(unittest.TestCase):
     def test_publictransport_when_error_invalid_input_data_occured(self):
         with open('testdata/models/routing_error_invalid_input_data.json', 'r') as f:
             expectedResponse = f.read()
-        responses.add(responses.GET, 'https://route.cit.api.here.com/routing/7.2/calculateroute.json',
+        responses.add(responses.GET, 'https://route.ls.hereapi.com/routing/7.2/calculateroute.json',
                   expectedResponse, status=200)
         with self.assertRaises(herepy.InvalidInputDataError):
             self._api.public_transport([11.0, 12.0],
@@ -269,9 +268,9 @@ class RoutingApiTest(unittest.TestCase):
     def test_publictransport_when_error_invalid_credentials_occured(self):
         with open('testdata/models/routing_error_invalid_credentials.json', 'r') as f:
             expectedResponse = f.read()
-        responses.add(responses.GET, 'https://route.cit.api.here.com/routing/7.2/calculateroute.json',
+        responses.add(responses.GET, 'https://route.ls.hereapi.com/routing/7.2/calculateroute.json',
                   expectedResponse, status=200)
-        api = herepy.RoutingApi('wrong_app_id', 'wrong_app_code')
+        api = herepy.RoutingApi('wrong_api_key', 'wrong_app_code')
         with self.assertRaises(herepy.InvalidCredentialsError):
             api.public_transport([11.0, 12.0],
                                  [15.0, 16.0],
@@ -281,7 +280,7 @@ class RoutingApiTest(unittest.TestCase):
     def test_publictransport_when_error_no_route_found_occured(self):
         with open('testdata/models/routing_error_no_route_found.json', 'r') as f:
             expectedResponse = f.read()
-        responses.add(responses.GET, 'https://route.cit.api.here.com/routing/7.2/calculateroute.json',
+        responses.add(responses.GET, 'https://route.ls.hereapi.com/routing/7.2/calculateroute.json',
                   expectedResponse, status=200)
         with self.assertRaises(herepy.NoRouteFoundError):
             self._api.public_transport([11.0, 12.0], [47.013399, -10.171986], True)
@@ -290,7 +289,7 @@ class RoutingApiTest(unittest.TestCase):
     def test_publictransporttimetable_withdefaultmodes_whensucceed(self):
         with codecs.open('testdata/models/routing_public_time_table.json', mode='r', encoding='utf-8') as f:
             expectedResponse = f.read()
-        responses.add(responses.GET, 'https://route.cit.api.here.com/routing/7.2/calculateroute.json',
+        responses.add(responses.GET, 'https://route.ls.hereapi.com/routing/7.2/calculateroute.json',
                   expectedResponse, status=200)
         response = self._api.public_transport_timetable([11.0, 12.0],
                                               [15.0, 16.0],
@@ -302,7 +301,7 @@ class RoutingApiTest(unittest.TestCase):
     def test_publictransporttimetable_route_short(self):
         with codecs.open('testdata/models/routing_public_time_table.json', mode='r', encoding='utf-8') as f:
             expectedResponse = f.read()
-        responses.add(responses.GET, 'https://route.cit.api.here.com/routing/7.2/calculateroute.json',
+        responses.add(responses.GET, 'https://route.ls.hereapi.com/routing/7.2/calculateroute.json',
                   expectedResponse, status=200)
         response = self._api.public_transport_timetable([11.0, 12.0],
                                               [15.0, 16.0],
@@ -316,7 +315,7 @@ class RoutingApiTest(unittest.TestCase):
     def test_locationnearmotorway_whensucceed(self):
         with codecs.open('testdata/models/routing.json', mode='r', encoding='utf-8') as f:
             expectedResponse = f.read()
-        responses.add(responses.GET, 'https://route.cit.api.here.com/routing/7.2/calculateroute.json',
+        responses.add(responses.GET, 'https://route.ls.hereapi.com/routing/7.2/calculateroute.json',
                   expectedResponse, status=200)
         response = self._api.location_near_motorway([11.0, 12.0],
                                                     [22.0, 23.0],
@@ -328,7 +327,7 @@ class RoutingApiTest(unittest.TestCase):
     def test_locationnearmotorway_withdefaultmodes_whensucceed(self):
         with codecs.open('testdata/models/routing.json', mode='r', encoding='utf-8') as f:
             expectedResponse = f.read()
-        responses.add(responses.GET, 'https://route.cit.api.here.com/routing/7.2/calculateroute.json',
+        responses.add(responses.GET, 'https://route.ls.hereapi.com/routing/7.2/calculateroute.json',
                   expectedResponse, status=200)
         response = self._api.location_near_motorway([11.0, 12.0],
                                                     [22.0, 23.0])
@@ -339,7 +338,7 @@ class RoutingApiTest(unittest.TestCase):
     def test_locationnearmotorway_when_error_invalid_input_data_occured(self):
         with open('testdata/models/routing_error_invalid_input_data.json', 'r') as f:
             expectedResponse = f.read()
-        responses.add(responses.GET, 'https://route.cit.api.here.com/routing/7.2/calculateroute.json',
+        responses.add(responses.GET, 'https://route.ls.hereapi.com/routing/7.2/calculateroute.json',
                   expectedResponse, status=200)
         with self.assertRaises(herepy.InvalidInputDataError):
             self._api.location_near_motorway([11.0, 12.0],
@@ -350,9 +349,9 @@ class RoutingApiTest(unittest.TestCase):
     def test_locationnearmotorway_when_error_invalid_credentials_occured(self):
         with open('testdata/models/routing_error_invalid_credentials.json', 'r') as f:
             expectedResponse = f.read()
-        responses.add(responses.GET, 'https://route.cit.api.here.com/routing/7.2/calculateroute.json',
+        responses.add(responses.GET, 'https://route.ls.hereapi.com/routing/7.2/calculateroute.json',
                   expectedResponse, status=200)
-        api = herepy.RoutingApi('wrong_app_id', 'wrong_app_code')
+        api = herepy.RoutingApi('wrong_api_key', 'wrong_app_code')
         with self.assertRaises(herepy.InvalidCredentialsError):
             api.location_near_motorway([11.0, 12.0], [22.0, 23.0])
 
@@ -360,7 +359,7 @@ class RoutingApiTest(unittest.TestCase):
     def test_locationnearmotorway_when_error_no_route_found_occured(self):
         with open('testdata/models/routing_error_no_route_found.json', 'r') as f:
             expectedResponse = f.read()
-        responses.add(responses.GET, 'https://route.cit.api.here.com/routing/7.2/calculateroute.json',
+        responses.add(responses.GET, 'https://route.ls.hereapi.com/routing/7.2/calculateroute.json',
                   expectedResponse, status=200)
         with self.assertRaises(herepy.NoRouteFoundError):
             self._api.location_near_motorway([11.0, 12.0], [47.013399, -10.171986])
@@ -369,7 +368,7 @@ class RoutingApiTest(unittest.TestCase):
     def test_truckroute_whensucceed(self):
         with codecs.open('testdata/models/routing.json', mode='r', encoding='utf-8') as f:
             expectedResponse = f.read()
-        responses.add(responses.GET, 'https://route.cit.api.here.com/routing/7.2/calculateroute.json',
+        responses.add(responses.GET, 'https://route.ls.hereapi.com/routing/7.2/calculateroute.json',
                   expectedResponse, status=200)
         response = self._api.truck_route([11.0, 12.0],
                                          [22.0, 23.0],
@@ -381,7 +380,7 @@ class RoutingApiTest(unittest.TestCase):
     def test_truckroute_route_short(self):
         with codecs.open('testdata/models/routing_truck_route_short.json', mode='r', encoding='utf-8') as f:
             expectedResponse = f.read()
-        responses.add(responses.GET, 'https://route.cit.api.here.com/routing/7.2/calculateroute.json',
+        responses.add(responses.GET, 'https://route.ls.hereapi.com/routing/7.2/calculateroute.json',
                   expectedResponse, status=200)
         response = self._api.truck_route([11.0, 12.0],
                                          [22.0, 23.0])
@@ -395,7 +394,7 @@ class RoutingApiTest(unittest.TestCase):
     def test_truckroute_withdefaultmodes_whensucceed(self):
         with codecs.open('testdata/models/routing.json', mode='r', encoding='utf-8') as f:
             expectedResponse = f.read()
-        responses.add(responses.GET, 'https://route.cit.api.here.com/routing/7.2/calculateroute.json',
+        responses.add(responses.GET, 'https://route.ls.hereapi.com/routing/7.2/calculateroute.json',
                   expectedResponse, status=200)
         response = self._api.truck_route([11.0, 12.0],
                                          [22.0, 23.0])
@@ -406,7 +405,7 @@ class RoutingApiTest(unittest.TestCase):
     def test_truckroute_when_error_invalid_input_data_occured(self):
         with open('testdata/models/routing_error_invalid_input_data.json', 'r') as f:
             expectedResponse = f.read()
-        responses.add(responses.GET, 'https://route.cit.api.here.com/routing/7.2/calculateroute.json',
+        responses.add(responses.GET, 'https://route.ls.hereapi.com/routing/7.2/calculateroute.json',
                   expectedResponse, status=200)
         with self.assertRaises(herepy.InvalidInputDataError):
             self._api.truck_route([11.0, 12.0],
@@ -417,9 +416,9 @@ class RoutingApiTest(unittest.TestCase):
     def test_truckroute_when_error_invalid_credentials_occured(self):
         with open('testdata/models/routing_error_invalid_credentials.json', 'r') as f:
             expectedResponse = f.read()
-        responses.add(responses.GET, 'https://route.cit.api.here.com/routing/7.2/calculateroute.json',
+        responses.add(responses.GET, 'https://route.ls.hereapi.com/routing/7.2/calculateroute.json',
                   expectedResponse, status=200)
-        api = herepy.RoutingApi('wrong_app_id', 'wrong_app_code')
+        api = herepy.RoutingApi('wrong_api_key', 'wrong_app_code')
         with self.assertRaises(herepy.InvalidCredentialsError):
             api.truck_route([11.0, 12.0], [22.0, 23.0])
 
@@ -427,7 +426,7 @@ class RoutingApiTest(unittest.TestCase):
     def test_truckroute_when_error_no_route_found_occured(self):
         with open('testdata/models/routing_error_no_route_found.json', 'r') as f:
             expectedResponse = f.read()
-        responses.add(responses.GET, 'https://route.cit.api.here.com/routing/7.2/calculateroute.json',
+        responses.add(responses.GET, 'https://route.ls.hereapi.com/routing/7.2/calculateroute.json',
                   expectedResponse, status=200)
         with self.assertRaises(herepy.NoRouteFoundError):
             self._api.truck_route([11.0, 12.0], [47.013399, -10.171986])
@@ -436,7 +435,7 @@ class RoutingApiTest(unittest.TestCase):
     def test_matrix_whensucceed(self):
         with codecs.open('testdata/models/routing_matrix.json', mode='r', encoding='utf-8') as f:
             server_response = f.read()
-        responses.add(responses.GET, 'https://matrix.route.api.here.com/routing/7.2/calculatematrix.json',
+        responses.add(responses.GET, 'https://matrix.route.ls.hereapi.com/routing/7.2/calculatematrix.json',
                       server_response, status=200)
         response = self._api.matrix(
             start_waypoints=[[9.933231, -84.076831]],
@@ -448,7 +447,7 @@ class RoutingApiTest(unittest.TestCase):
     def test_matrix_multiple_starts(self):
         with codecs.open('testdata/models/routing_matrix_multiple_starts.json', mode='r', encoding='utf-8') as f:
             server_response = f.read()
-        responses.add(responses.GET, 'https://matrix.route.api.here.com/routing/7.2/calculatematrix.json',
+        responses.add(responses.GET, 'https://matrix.route.ls.hereapi.com/routing/7.2/calculatematrix.json',
                       server_response, status=200)
         response = self._api.matrix(
             start_waypoints=[[9.933231, -84.076831], [9.934574, -84.065544]],
@@ -460,7 +459,7 @@ class RoutingApiTest(unittest.TestCase):
     def test_matrix_multiple_destinations(self):
         with codecs.open('testdata/models/routing_matrix_multiple_destinations.json', mode='r', encoding='utf-8') as f:
             server_response = f.read()
-        responses.add(responses.GET, 'https://matrix.route.api.here.com/routing/7.2/calculatematrix.json',
+        responses.add(responses.GET, 'https://matrix.route.ls.hereapi.com/routing/7.2/calculatematrix.json',
                       server_response, status=200)
         response = self._api.matrix(
             start_waypoints=[[9.933231, -84.076831]],
@@ -472,7 +471,7 @@ class RoutingApiTest(unittest.TestCase):
     def test_matrix_bad_request(self):
         with codecs.open('testdata/models/routing_matrix_bad_request.json', mode='r', encoding='utf-8') as f:
             server_response = f.read()
-        responses.add(responses.GET, 'https://matrix.route.api.here.com/routing/7.2/calculatematrix.json',
+        responses.add(responses.GET, 'https://matrix.route.ls.hereapi.com/routing/7.2/calculatematrix.json',
                       server_response, status=400)
         with self.assertRaises(herepy.InvalidInputDataError):
             self._api.matrix(
@@ -484,7 +483,7 @@ class RoutingApiTest(unittest.TestCase):
     def test_departure_as_datetime(self):
         with codecs.open('testdata/models/routing_truck_route_short.json', mode='r', encoding='utf-8') as f:
             expectedResponse = f.read()
-        responses.add(responses.GET, 'https://route.cit.api.here.com/routing/7.2/calculateroute.json',
+        responses.add(responses.GET, 'https://route.ls.hereapi.com/routing/7.2/calculateroute.json',
                   expectedResponse, status=200)
         date = datetime.datetime(2013, 7, 4, 17, 0, tzinfo=datetime.timezone(datetime.timedelta(0, 7200)))
         response = self._api.truck_route([11.0, 12.0],
@@ -495,7 +494,7 @@ class RoutingApiTest(unittest.TestCase):
     def test_departure_as_string(self):
         with codecs.open('testdata/models/routing_truck_route_short.json', mode='r', encoding='utf-8') as f:
             expectedResponse = f.read()
-        responses.add(responses.GET, 'https://route.cit.api.here.com/routing/7.2/calculateroute.json',
+        responses.add(responses.GET, 'https://route.ls.hereapi.com/routing/7.2/calculateroute.json',
                   expectedResponse, status=200)
         date = "2013-07-04T17:00:00+02:00"
         response = self._api.truck_route([11.0, 12.0],


### PR DESCRIPTION
- There is some inconsistency on the use of `apiKey`, sometimes we
have to use `apiKey` sometimes `apikey`.
- As I checked for most of the endpoints responses are same.