### PR TITLE
Extend PublicTransitApi calculate_route

### DIFF
--- a/herepy/__init__.py
+++ b/herepy/__init__.py
@@ -22,6 +22,7 @@ from .here_enum import (
     PlacesCategory,
     PublicTransitSearchMethod,
     PublicTransitRoutingType,
+    PublicTransitModeType,
     WeatherProductType
 )
 

--- a/herepy/__init__.py
+++ b/herepy/__init__.py
@@ -21,7 +21,7 @@ from .here_enum import (
     MatrixSummaryAttribute,
     PlacesCategory,
     PublicTransitSearchMethod,
-    PublicTransitRoutingType,
+    PublicTransitRoutingMode,
     PublicTransitModeType,
     WeatherProductType
 )

--- a/herepy/here_enum.py
+++ b/herepy/here_enum.py
@@ -68,12 +68,11 @@ class PublicTransitSearchMethod(Enum):
     def __str__(self):
         return '%s' % self._value_
 
-class PublicTransitRoutingType(Enum):
+class PublicTransitRoutingMode(Enum):
     """Routing types used in public transit api"""
 
-    time_tabled = 'tt'
-    simple = 'sr'
-    all = 'all'
+    schedule = 'schedule'
+    realtime = 'realtime'
 
     def __str__(self):
         return '%s' % self._value_
@@ -81,22 +80,22 @@ class PublicTransitRoutingType(Enum):
 class PublicTransitModeType(Enum):
     """Mode types used in public transit api"""
 
-    high_speed_train = 'high_speed_train'
-    intercity_train = 'intercity_train'
-    inter_regional_train = 'inter_regional_train'
-    regional_train = 'regional_train'
-    city_train = 'city_train'
-    bus = 'bus'
-    ferry = 'ferry'
-    subway = 'subway'
-    light_rail = 'light_rail'
-    private_bus = 'private_bus'
-    inclined = 'inclined'
-    aerial = 'aerial'
-    bus_rapid = 'bus_rapid'
-    monorail = 'monorail'
-    flight = 'flight'
-    walk = 'walk'
+    high_speed_train = 0
+    intercity_train = 1
+    inter_regional_train = 2
+    regional_train = 3
+    city_train = 4
+    bus = 5
+    ferry = 6
+    subway = 7
+    light_rail = 8
+    private_bus = 9
+    inclined = 10
+    aerial = 11
+    bus_rapid = 12
+    monorail = 13
+    flight = 14
+    walk = 20
 
     def __str__(self):
         return '%s' % self._value_

--- a/herepy/here_enum.py
+++ b/herepy/here_enum.py
@@ -77,6 +77,29 @@ class PublicTransitRoutingType(Enum):
 
     def __str__(self):
         return '%s' % self._value_
+
+class PublicTransitModeType(Enum):
+    """Mode types used in public transit api"""
+
+    high_speed_train = 'high_speed_train'
+    intercity_train = 'intercity_train'
+    inter_regional_train = 'inter_regional_train'
+    regional_train = 'regional_train'
+    city_train = 'city_train'
+    bus = 'bus'
+    ferry = 'ferry'
+    subway = 'subway'
+    light_rail = 'light_rail'
+    private_bus = 'private_bus'
+    inclined = 'inclined'
+    aerial = 'aerial'
+    bus_rapid = 'bus_rapid'
+    monorail = 'monorail'
+    flight = 'flight'
+    walk = 'walk'
+
+    def __str__(self):
+        return '%s' % self._value_
     
 class WeatherProductType(Enum):
     """Identifis the type of report to obtain."""

--- a/herepy/public_transit_api.py
+++ b/herepy/public_transit_api.py
@@ -305,7 +305,7 @@ class PublicTransitApi(HEREApi):
             data["modes"] = modes
 
         response = self.__get(data, 'route.json', 'Connections')
-        response_with_short_route = _get_response_with_short_route(response)
+        response_with_short_route = self._get_response_with_short_route(response)
         return response_with_short_route
 
     def coverage_witin_a_city(self,
@@ -360,20 +360,20 @@ class PublicTransitApi(HEREApi):
                 'apikey': self._api_key}
         return self.__get(data, 'coverage/nearby.json', 'LocalCoverage')
 
-def _get_response_with_short_route(public_transit_response):
-    response = public_transit_response
-    connections = response.Res["Connections"]["Connection"]
+    def _get_response_with_short_route(self, public_transit_response):
+        response = public_transit_response
+        connections = response.Res["Connections"]["Connection"]
 
-    for connection in connections:
-      connection["short_route"] = _get_route_from_public_transit_connection(connection)
-    return response
+        for connection in connections:
+            connection["short_route"] = self._get_route_from_public_transit_connection(connection)
+        return response
 
-def _get_route_from_public_transit_connection(public_transit_connection):
-      sections = public_transit_connection["Sections"]["Sec"]
-      lines = []
-      for section in sections:
-        if str(section["mode"]) != str(PublicTransitModeType["walk"]):
-          transport = section["Dep"]["Transport"]
-          lines.append(transport["name"] + " - " + transport["dir"])
-      route = "; ".join(list(map(str, lines)))
-      return route
+    def _get_route_from_public_transit_connection(self, public_transit_connection):
+        sections = public_transit_connection["Sections"]["Sec"]
+        lines = []
+        for section in sections:
+            if str(section["mode"]) != str(PublicTransitModeType["walk"]):
+                transport = section["Dep"]["Transport"]
+                lines.append(transport["name"] + " - " + transport["dir"])
+        route = "; ".join(list(map(str, lines)))
+        return route

--- a/herepy/public_transit_api.py
+++ b/herepy/public_transit_api.py
@@ -32,7 +32,6 @@ class PublicTransitApi(HEREApi):
 
     def __get(self, data, path, json_node):
         url = Utils.build_url(self._base_url + path, extra_params=data)
-        print(url)
         response = requests.get(url, timeout=self._timeout)
         json_data = json.loads(response.content.decode('utf8'))
         if json_node in json_data.get('Res', {}):

--- a/herepy/public_transit_api.py
+++ b/herepy/public_transit_api.py
@@ -231,7 +231,8 @@ class PublicTransitApi(HEREApi):
                         departure,
                         arrival,
                         time,
-                        changes=3,
+                        max_connections=3,
+                        changes=-1,
                         lang="en",
                         include_modes=None,
                         exclude_modes=None,
@@ -249,9 +250,13 @@ class PublicTransitApi(HEREApi):
             array including latitude and longitude in order.
           time (str):
             time formatted in yyyy-mm-ddThh:mm:ss.
-          changes (int):
+          max_connections (int):
             Specifies the number of following departure/arrivals the response should include.
             The possible values are: 1-6.
+          changes (int):
+            Specifies the maximum number of changes or transfers allowed in a route.
+            0-6 or -1.
+            The default is -1 (which disables the filter, or unlimited no of changes permitted).
           lang (str):
             Specifies the language of the response.
           include_modes (array[PublicTransitModeType]):
@@ -278,6 +283,7 @@ class PublicTransitApi(HEREApi):
 
         data = {'dep': str.format('{0},{1}', departure[0], departure[1]),
                 'arr': str.format('{0},{1}', arrival[0], arrival[1]),
+                'max': max_connections,
                 'time': time,
                 'changes': changes,
                 'lang': lang,

--- a/testdata/models/public_transit_api_calculate_route_many_transfers.json
+++ b/testdata/models/public_transit_api_calculate_route_many_transfers.json
@@ -1,0 +1,4948 @@
+{
+    "Res": {
+        "serviceUrl": "http://nokia.hafas.de/hafas-proxy-nokia-hci/db",
+        "Connections": {
+            "allow_direction": "F",
+            "context": "P9LPjFipN9AyIGEVhMXG0P__AACM9QFeEv0C_9AHZA",
+            "Connection": [
+                {
+                    "id": "R001634-C0",
+                    "duration": "PT5H27M",
+                    "transfers": 3,
+                    "Dep": {
+                        "time": "2019-12-24T11:01:00",
+                        "Addr": {
+                            "x": 8.276386,
+                            "y": 49.999252
+                        }
+                    },
+                    "Arr": {
+                        "time": "2019-12-24T16:28:00",
+                        "Addr": {
+                            "x": 13.403411,
+                            "y": 52.521436
+                        }
+                    },
+                    "Sections": {
+                        "Sec": [
+                            {
+                                "mode": 20,
+                                "id": "R001634-C0-S0",
+                                "Dep": {
+                                    "time": "2019-12-24T11:01:00",
+                                    "Addr": {
+                                        "x": 8.276386,
+                                        "y": 49.999252
+                                    },
+                                    "Transport": {
+                                        "mode": 20
+                                    }
+                                },
+                                "Journey": {
+                                    "duration": "PT13M",
+                                    "distance": 649
+                                },
+                                "Arr": {
+                                    "time": "2019-12-24T11:14:00",
+                                    "Stn": {
+                                        "id": "db_8003816#81",
+                                        "name": "Mainz Römisches Theater",
+                                        "x": 8.277564,
+                                        "y": 49.993463
+                                    }
+                                }
+                            },
+                            {
+                                "mode": 3,
+                                "id": "R001634-C0-S1",
+                                "Dep": {
+                                    "time": "2019-12-24T11:14:00",
+                                    "platform": "3",
+                                    "Stn": {
+                                        "id": "db_8003816#81",
+                                        "name": "Mainz Römisches Theater",
+                                        "x": 8.277564,
+                                        "y": 49.993463
+                                    },
+                                    "Transport": {
+                                        "mode": 3,
+                                        "dir": "Frankfurt(Main)Hbf",
+                                        "name": "RE 29511",
+                                        "At": {
+                                            "category": "vlexx",
+                                            "operator": "DB",
+                                            "color": "#EC1B2D"
+                                        }
+                                    },
+                                    "Freq": {
+                                        "min": 60,
+                                        "max": 60,
+                                        "AltDep": [
+                                            {
+                                                "time": "2019-12-24T12:14:00",
+                                                "Transport": {
+                                                    "mode": 3,
+                                                    "dir": "Frankfurt(Main)Hbf",
+                                                    "name": "RE 4259",
+                                                    "At": {
+                                                        "category": "Regional-Express",
+                                                        "operator": "DB",
+                                                        "color": "#EC1B2D"
+                                                    }
+                                                }
+                                            },
+                                            {
+                                                "time": "2019-12-24T13:14:00",
+                                                "Transport": {
+                                                    "mode": 3,
+                                                    "dir": "Frankfurt(Main)Hbf",
+                                                    "name": "RE 29515",
+                                                    "At": {
+                                                        "category": "vlexx",
+                                                        "operator": "DB",
+                                                        "color": "#EC1B2D"
+                                                    }
+                                                }
+                                            },
+                                            {
+                                                "time": "2019-12-24T14:14:00",
+                                                "Transport": {
+                                                    "mode": 3,
+                                                    "dir": "Frankfurt(Main)Hbf",
+                                                    "name": "RE 4261",
+                                                    "At": {
+                                                        "category": "Regional-Express",
+                                                        "operator": "DB",
+                                                        "color": "#EC1B2D"
+                                                    }
+                                                }
+                                            }
+                                        ]
+                                    }
+                                },
+                                "Journey": {
+                                    "duration": "PT35M",
+                                    "Stop": [
+                                        {
+                                            "dep": "2019-12-24T11:14:00",
+                                            "arr": "2019-12-24T11:13:00",
+                                            "Stn": {
+                                                "id": "db_8003816#81",
+                                                "name": "Mainz Römisches Theater",
+                                                "x": 8.277564,
+                                                "y": 49.993463
+                                            }
+                                        },
+                                        {
+                                            "dep": "2019-12-24T11:19:00",
+                                            "arr": "2019-12-24T11:18:00",
+                                            "Stn": {
+                                                "id": "db_8000241#81",
+                                                "name": "Mainz-Bischofsheim",
+                                                "x": 8.357496,
+                                                "y": 49.993229
+                                            }
+                                        },
+                                        {
+                                            "dep": "2019-12-24T11:23:00",
+                                            "arr": "2019-12-24T11:22:00",
+                                            "Stn": {
+                                                "id": "db_8005220#81",
+                                                "name": "Rüsselsheim",
+                                                "x": 8.41358,
+                                                "y": 49.991638
+                                            }
+                                        },
+                                        {
+                                            "dep": "2019-12-24T11:35:00",
+                                            "arr": "2019-12-24T11:34:00",
+                                            "Stn": {
+                                                "id": "db_8070004#81",
+                                                "name": "Frankfurt(M) Flughafen Regionalbf",
+                                                "x": 8.57125,
+                                                "y": 50.051219
+                                            }
+                                        },
+                                        {
+                                            "dep": "2019-12-24T11:44:00",
+                                            "arr": "2019-12-24T11:43:00",
+                                            "Stn": {
+                                                "id": "db_8002050#81",
+                                                "name": "Frankfurt-Niederrad",
+                                                "x": 8.637079,
+                                                "y": 50.081287
+                                            }
+                                        },
+                                        {
+                                            "arr": "2019-12-24T11:49:00",
+                                            "Stn": {
+                                                "id": "db_8000105#81",
+                                                "name": "Frankfurt(Main)Hbf",
+                                                "x": 8.663785,
+                                                "y": 50.107149
+                                            }
+                                        }
+                                    ]
+                                },
+                                "Arr": {
+                                    "time": "2019-12-24T11:49:00",
+                                    "platform": "20",
+                                    "Stn": {
+                                        "id": "db_8000105#81",
+                                        "name": "Frankfurt(Main)Hbf",
+                                        "x": 8.663785,
+                                        "y": 50.107149
+                                    }
+                                }
+                            },
+                            {
+                                "mode": 0,
+                                "id": "R001634-C0-S2",
+                                "Dep": {
+                                    "time": "2019-12-24T11:58:00",
+                                    "platform": "8",
+                                    "Stn": {
+                                        "id": "db_8000105#81",
+                                        "name": "Frankfurt(Main)Hbf",
+                                        "x": 8.663785,
+                                        "y": 50.107149
+                                    },
+                                    "Transport": {
+                                        "mode": 0,
+                                        "dir": "Hamburg-Altona",
+                                        "name": "ICE 76",
+                                        "At": {
+                                            "category": "Intercity-Express",
+                                            "operator": "DB",
+                                            "color": "#EC1B2D"
+                                        }
+                                    },
+                                    "Freq": {
+                                        "min": 60,
+                                        "max": 60,
+                                        "AltDep": [
+                                            {
+                                                "time": "2019-12-24T12:58:00",
+                                                "Transport": {
+                                                    "mode": 0,
+                                                    "dir": "Hamburg-Altona",
+                                                    "name": "ICE 578",
+                                                    "At": {
+                                                        "category": "Intercity-Express",
+                                                        "operator": "DB",
+                                                        "color": "#EC1B2D"
+                                                    }
+                                                }
+                                            },
+                                            {
+                                                "time": "2019-12-24T13:58:00",
+                                                "Transport": {
+                                                    "mode": 0,
+                                                    "dir": "Kiel Hbf",
+                                                    "name": "ICE 74",
+                                                    "At": {
+                                                        "category": "Intercity-Express",
+                                                        "operator": "DB",
+                                                        "color": "#EC1B2D"
+                                                    }
+                                                }
+                                            },
+                                            {
+                                                "time": "2019-12-24T14:58:00",
+                                                "Transport": {
+                                                    "mode": 0,
+                                                    "dir": "Hamburg-Altona",
+                                                    "name": "ICE 576",
+                                                    "At": {
+                                                        "category": "Intercity-Express",
+                                                        "operator": "DB",
+                                                        "color": "#EC1B2D"
+                                                    }
+                                                }
+                                            }
+                                        ]
+                                    }
+                                },
+                                "Journey": {
+                                    "duration": "PT2H19M",
+                                    "Stop": [
+                                        {
+                                            "dep": "2019-12-24T11:58:00",
+                                            "arr": "2019-12-24T11:52:00",
+                                            "Stn": {
+                                                "id": "db_8000105#81",
+                                                "name": "Frankfurt(Main)Hbf",
+                                                "x": 8.663785,
+                                                "y": 50.107149
+                                            }
+                                        },
+                                        {
+                                            "dep": "2019-12-24T13:21:00",
+                                            "arr": "2019-12-24T13:19:00",
+                                            "Stn": {
+                                                "id": "db_8003200#81",
+                                                "name": "Kassel-Wilhelmshöhe",
+                                                "x": 9.446899,
+                                                "y": 51.313115
+                                            }
+                                        },
+                                        {
+                                            "dep": "2019-12-24T13:40:00",
+                                            "arr": "2019-12-24T13:38:00",
+                                            "Stn": {
+                                                "id": "db_8000128#81",
+                                                "name": "Göttingen",
+                                                "x": 9.926069,
+                                                "y": 51.536812
+                                            }
+                                        },
+                                        {
+                                            "dep": "2019-12-24T14:20:00",
+                                            "arr": "2019-12-24T14:17:00",
+                                            "Stn": {
+                                                "id": "db_8000152#81",
+                                                "name": "Hannover Hbf",
+                                                "x": 9.741017,
+                                                "y": 52.376764
+                                            }
+                                        }
+                                    ]
+                                },
+                                "Arr": {
+                                    "time": "2019-12-24T14:17:00",
+                                    "platform": "7",
+                                    "Stn": {
+                                        "id": "db_8000152#81",
+                                        "name": "Hannover Hbf",
+                                        "x": 9.741017,
+                                        "y": 52.376764
+                                    }
+                                }
+                            },
+                            {
+                                "mode": 0,
+                                "id": "R001634-C0-S3",
+                                "Dep": {
+                                    "time": "2019-12-24T14:31:00",
+                                    "platform": "9",
+                                    "Stn": {
+                                        "id": "db_8000152#81",
+                                        "name": "Hannover Hbf",
+                                        "x": 9.741017,
+                                        "y": 52.376764
+                                    },
+                                    "Transport": {
+                                        "mode": 0,
+                                        "dir": "Berlin Gesundbrunnen",
+                                        "name": "ICE 849",
+                                        "At": {
+                                            "category": "Intercity-Express",
+                                            "operator": "DB",
+                                            "color": "#EC1B2D"
+                                        }
+                                    },
+                                    "Freq": {
+                                        "min": 60,
+                                        "max": 60,
+                                        "AltDep": [
+                                            {
+                                                "time": "2019-12-24T15:31:00",
+                                                "Transport": {
+                                                    "mode": 0,
+                                                    "dir": "Berlin Gesundbrunnen",
+                                                    "name": "ICE 549",
+                                                    "At": {
+                                                        "category": "Intercity-Express",
+                                                        "operator": "DB",
+                                                        "color": "#EC1B2D"
+                                                    }
+                                                }
+                                            },
+                                            {
+                                                "time": "2019-12-24T16:31:00",
+                                                "Transport": {
+                                                    "mode": 0,
+                                                    "dir": "Berlin Südkreuz",
+                                                    "name": "ICE 941",
+                                                    "At": {
+                                                        "category": "Intercity-Express",
+                                                        "operator": "DB",
+                                                        "color": "#EC1B2D"
+                                                    }
+                                                }
+                                            },
+                                            {
+                                                "time": "2019-12-24T17:31:00",
+                                                "Transport": {
+                                                    "mode": 0,
+                                                    "dir": "Berlin Gesundbrunnen",
+                                                    "name": "ICE 641",
+                                                    "At": {
+                                                        "category": "Intercity-Express",
+                                                        "operator": "DB",
+                                                        "color": "#EC1B2D"
+                                                    }
+                                                }
+                                            }
+                                        ]
+                                    }
+                                },
+                                "Journey": {
+                                    "duration": "PT1H39M",
+                                    "Stop": [
+                                        {
+                                            "dep": "2019-12-24T14:31:00",
+                                            "arr": "2019-12-24T14:28:00",
+                                            "Stn": {
+                                                "id": "db_8000152#81",
+                                                "name": "Hannover Hbf",
+                                                "x": 9.741017,
+                                                "y": 52.376764
+                                            }
+                                        },
+                                        {
+                                            "dep": "2019-12-24T15:05:00",
+                                            "arr": "2019-12-24T15:03:00",
+                                            "Stn": {
+                                                "id": "db_8006552#81",
+                                                "name": "Wolfsburg Hbf",
+                                                "x": 10.787784,
+                                                "y": 52.429495
+                                            }
+                                        },
+                                        {
+                                            "arr": "2019-12-24T15:58:00",
+                                            "Stn": {
+                                                "id": "db_8010404#81",
+                                                "name": "Berlin-Spandau",
+                                                "x": 13.196902,
+                                                "y": 52.53465
+                                            }
+                                        },
+                                        {
+                                            "arr": "2019-12-24T16:10:00",
+                                            "Stn": {
+                                                "id": "db_8098160#81",
+                                                "name": "Berlin Hbf (tief)",
+                                                "x": 13.369549,
+                                                "y": 52.525589
+                                            }
+                                        }
+                                    ]
+                                },
+                                "Arr": {
+                                    "time": "2019-12-24T16:10:00",
+                                    "platform": "5",
+                                    "Stn": {
+                                        "id": "db_8098160#81",
+                                        "name": "Berlin Hbf (tief)",
+                                        "x": 13.369549,
+                                        "y": 52.525589
+                                    }
+                                }
+                            },
+                            {
+                                "mode": 20,
+                                "id": "R001634-C0-S4",
+                                "Dep": {
+                                    "time": "2019-12-24T16:10:00",
+                                    "Stn": {
+                                        "id": "db_8098160#81",
+                                        "name": "Berlin Hbf (tief)",
+                                        "x": 13.369549,
+                                        "y": 52.525589
+                                    },
+                                    "Transport": {
+                                        "mode": 20
+                                    }
+                                },
+                                "Journey": {
+                                    "duration": "PT9M",
+                                    "distance": 500
+                                },
+                                "Arr": {
+                                    "time": "2019-12-24T16:19:00",
+                                    "Stn": {
+                                        "id": "db_8089021#81",
+                                        "name": "Berlin Hbf (S-Bahn)",
+                                        "x": 13.369549,
+                                        "y": 52.525589
+                                    }
+                                }
+                            },
+                            {
+                                "mode": 4,
+                                "id": "R001634-C0-S5",
+                                "Dep": {
+                                    "time": "2019-12-24T16:21:00",
+                                    "platform": "15",
+                                    "Stn": {
+                                        "id": "db_8089021#81",
+                                        "name": "Berlin Hbf (S-Bahn)",
+                                        "x": 13.369549,
+                                        "y": 52.525589
+                                    },
+                                    "Transport": {
+                                        "mode": 4,
+                                        "dir": "Strausberg Nord",
+                                        "name": "S5",
+                                        "At": {
+                                            "category": "S-Bahn",
+                                            "operator": "DB",
+                                            "color": "#F27B26"
+                                        }
+                                    },
+                                    "Freq": {
+                                        "min": 3,
+                                        "max": 10,
+                                        "AltDep": [
+                                            {
+                                                "time": "2019-12-24T16:25:00",
+                                                "Transport": {
+                                                    "mode": 4,
+                                                    "dir": "Berlin-Schönefeld Flughafen",
+                                                    "name": "S9",
+                                                    "At": {
+                                                        "category": "S-Bahn",
+                                                        "operator": "DB",
+                                                        "color": "#953450"
+                                                    }
+                                                }
+                                            },
+                                            {
+                                                "time": "2019-12-24T16:28:00",
+                                                "Transport": {
+                                                    "mode": 4,
+                                                    "dir": "Ahrensfelde (S)",
+                                                    "name": "S7",
+                                                    "At": {
+                                                        "category": "S-Bahn",
+                                                        "operator": "DB",
+                                                        "color": "#7D6AAA"
+                                                    }
+                                                }
+                                            },
+                                            {
+                                                "time": "2019-12-24T16:31:00",
+                                                "Transport": {
+                                                    "mode": 4,
+                                                    "dir": "Berlin-Mahlsdorf (S)",
+                                                    "name": "S5",
+                                                    "At": {
+                                                        "category": "S-Bahn",
+                                                        "operator": "DB",
+                                                        "color": "#F27B26"
+                                                    }
+                                                }
+                                            }
+                                        ]
+                                    }
+                                },
+                                "Journey": {
+                                    "duration": "PT4M",
+                                    "Stop": [
+                                        {
+                                            "dep": "2019-12-24T16:21:00",
+                                            "arr": "2019-12-24T16:20:00",
+                                            "Stn": {
+                                                "id": "db_8089021#81",
+                                                "name": "Berlin Hbf (S-Bahn)",
+                                                "x": 13.369549,
+                                                "y": 52.525589
+                                            }
+                                        },
+                                        {
+                                            "dep": "2019-12-24T16:23:00",
+                                            "Stn": {
+                                                "id": "db_8089066#81",
+                                                "name": "Berlin Friedrichstraße (S)",
+                                                "x": 13.386907,
+                                                "y": 52.520178
+                                            }
+                                        },
+                                        {
+                                            "dep": "2019-12-24T16:25:00",
+                                            "Stn": {
+                                                "id": "db_8089017#81",
+                                                "name": "Berlin Hackescher Markt",
+                                                "x": 13.402368,
+                                                "y": 52.522623
+                                            }
+                                        }
+                                    ]
+                                },
+                                "Arr": {
+                                    "time": "2019-12-24T16:25:00",
+                                    "platform": "3",
+                                    "Stn": {
+                                        "id": "db_8089017#81",
+                                        "name": "Berlin Hackescher Markt",
+                                        "x": 13.402368,
+                                        "y": 52.522623
+                                    }
+                                }
+                            },
+                            {
+                                "mode": 20,
+                                "id": "R001634-C0-S6",
+                                "Dep": {
+                                    "time": "2019-12-24T16:25:00",
+                                    "Stn": {
+                                        "id": "db_8089017#81",
+                                        "name": "Berlin Hackescher Markt",
+                                        "x": 13.402368,
+                                        "y": 52.522623
+                                    },
+                                    "Transport": {
+                                        "mode": 20
+                                    }
+                                },
+                                "Journey": {
+                                    "duration": "PT3M",
+                                    "distance": 149
+                                },
+                                "Arr": {
+                                    "time": "2019-12-24T16:28:00",
+                                    "Addr": {
+                                        "x": 13.403411,
+                                        "y": 52.521436
+                                    }
+                                }
+                            }
+                        ]
+                    }
+                },
+                {
+                    "id": "R001634-C1",
+                    "duration": "PT5H26M",
+                    "transfers": 2,
+                    "Dep": {
+                        "time": "2019-12-24T11:16:00",
+                        "Addr": {
+                            "x": 8.276386,
+                            "y": 49.999252
+                        }
+                    },
+                    "Arr": {
+                        "time": "2019-12-24T16:42:00",
+                        "Addr": {
+                            "x": 13.403411,
+                            "y": 52.521436
+                        }
+                    },
+                    "Sections": {
+                        "Sec": [
+                            {
+                                "mode": 20,
+                                "id": "R001634-C1-S0",
+                                "Dep": {
+                                    "time": "2019-12-24T11:16:00",
+                                    "Addr": {
+                                        "x": 8.276386,
+                                        "y": 49.999252
+                                    },
+                                    "Transport": {
+                                        "mode": 20
+                                    }
+                                },
+                                "Journey": {
+                                    "duration": "PT26M",
+                                    "distance": 1279
+                                },
+                                "Arr": {
+                                    "time": "2019-12-24T11:42:00",
+                                    "Stn": {
+                                        "id": "db_8000240#81",
+                                        "name": "Mainz Hbf",
+                                        "x": 8.258723,
+                                        "y": 50.001113
+                                    }
+                                }
+                            },
+                            {
+                                "mode": 0,
+                                "id": "R001634-C1-S1",
+                                "Dep": {
+                                    "time": "2019-12-24T11:42:00",
+                                    "platform": "4a/b",
+                                    "Stn": {
+                                        "id": "db_8000240#81",
+                                        "name": "Mainz Hbf",
+                                        "x": 8.258723,
+                                        "y": 50.001113
+                                    },
+                                    "Transport": {
+                                        "mode": 0,
+                                        "dir": "Wien Hbf",
+                                        "name": "ICE 27",
+                                        "At": {
+                                            "category": "Intercity-Express",
+                                            "operator": "DB",
+                                            "color": "#EC1B2D"
+                                        }
+                                    },
+                                    "Freq": {
+                                        "min": 59,
+                                        "max": 61,
+                                        "AltDep": [
+                                            {
+                                                "time": "2019-12-24T12:43:00",
+                                                "Transport": {
+                                                    "mode": 0,
+                                                    "dir": "Dresden Hbf",
+                                                    "name": "ICE 1651",
+                                                    "At": {
+                                                        "category": "Intercity-Express",
+                                                        "operator": "DB",
+                                                        "color": "#EC1B2D"
+                                                    }
+                                                }
+                                            },
+                                            {
+                                                "time": "2019-12-24T13:42:00",
+                                                "Transport": {
+                                                    "mode": 0,
+                                                    "dir": "Frankfurt(Main)Hbf",
+                                                    "name": "ICE 923",
+                                                    "At": {
+                                                        "category": "Intercity-Express",
+                                                        "operator": "DB",
+                                                        "color": "#EC1B2D"
+                                                    }
+                                                }
+                                            },
+                                            {
+                                                "time": "2019-12-24T14:43:00",
+                                                "Transport": {
+                                                    "mode": 0,
+                                                    "dir": "Dresden Hbf",
+                                                    "name": "ICE 1653",
+                                                    "At": {
+                                                        "category": "Intercity-Express",
+                                                        "operator": "DB",
+                                                        "color": "#EC1B2D"
+                                                    }
+                                                }
+                                            }
+                                        ]
+                                    }
+                                },
+                                "Journey": {
+                                    "duration": "PT17M",
+                                    "Stop": [
+                                        {
+                                            "dep": "2019-12-24T11:42:00",
+                                            "arr": "2019-12-24T11:39:00",
+                                            "Stn": {
+                                                "id": "db_8000240#81",
+                                                "name": "Mainz Hbf",
+                                                "x": 8.258723,
+                                                "y": 50.001113
+                                            }
+                                        },
+                                        {
+                                            "dep": "2019-12-24T12:02:00",
+                                            "arr": "2019-12-24T11:59:00",
+                                            "Stn": {
+                                                "id": "db_8070003#81",
+                                                "name": "Frankfurt(M) Flughafen Fernbf",
+                                                "x": 8.570181,
+                                                "y": 50.053169
+                                            }
+                                        }
+                                    ]
+                                },
+                                "Arr": {
+                                    "time": "2019-12-24T11:59:00",
+                                    "platform": "Fern 5",
+                                    "Stn": {
+                                        "id": "db_8070003#81",
+                                        "name": "Frankfurt(M) Flughafen Fernbf",
+                                        "x": 8.570181,
+                                        "y": 50.053169
+                                    }
+                                }
+                            },
+                            {
+                                "mode": 0,
+                                "id": "R001634-C1-S2",
+                                "Dep": {
+                                    "time": "2019-12-24T12:09:00",
+                                    "platform": "Fern 4",
+                                    "Stn": {
+                                        "id": "db_8070003#81",
+                                        "name": "Frankfurt(M) Flughafen Fernbf",
+                                        "x": 8.570181,
+                                        "y": 50.053169
+                                    },
+                                    "Transport": {
+                                        "mode": 0,
+                                        "dir": "Berlin Ostbahnhof",
+                                        "name": "ICE 798",
+                                        "At": {
+                                            "category": "Intercity-Express",
+                                            "operator": "DB",
+                                            "color": "#EC1B2D"
+                                        }
+                                    },
+                                    "Freq": {
+                                        "min": 120,
+                                        "max": 120,
+                                        "AltDep": [
+                                            {
+                                                "time": "2019-12-24T14:09:00",
+                                                "Transport": {
+                                                    "mode": 0,
+                                                    "dir": "Berlin Ostbahnhof",
+                                                    "name": "ICE 1196",
+                                                    "At": {
+                                                        "category": "Intercity-Express",
+                                                        "operator": "DB",
+                                                        "color": "#EC1B2D"
+                                                    }
+                                                }
+                                            },
+                                            {
+                                                "time": "2019-12-24T16:09:00",
+                                                "Transport": {
+                                                    "mode": 0,
+                                                    "dir": "Berlin Ostbahnhof",
+                                                    "name": "ICE 794",
+                                                    "At": {
+                                                        "category": "Intercity-Express",
+                                                        "operator": "DB",
+                                                        "color": "#EC1B2D"
+                                                    }
+                                                }
+                                            }
+                                        ]
+                                    }
+                                },
+                                "Journey": {
+                                    "duration": "PT4H17M",
+                                    "Stop": [
+                                        {
+                                            "dep": "2019-12-24T12:09:00",
+                                            "Stn": {
+                                                "id": "db_8070003#81",
+                                                "name": "Frankfurt(M) Flughafen Fernbf",
+                                                "x": 8.570181,
+                                                "y": 50.053169
+                                            }
+                                        },
+                                        {
+                                            "dep": "2019-12-24T12:20:00",
+                                            "arr": "2019-12-24T12:18:00",
+                                            "Stn": {
+                                                "id": "db_8002041#81",
+                                                "name": "Frankfurt(Main)Süd",
+                                                "x": 8.686456,
+                                                "y": 50.099365
+                                            }
+                                        },
+                                        {
+                                            "dep": "2019-12-24T13:13:00",
+                                            "arr": "2019-12-24T13:11:00",
+                                            "Stn": {
+                                                "id": "db_8000115#81",
+                                                "name": "Fulda",
+                                                "x": 9.68398,
+                                                "y": 50.554722
+                                            }
+                                        },
+                                        {
+                                            "dep": "2019-12-24T13:47:00",
+                                            "arr": "2019-12-24T13:45:00",
+                                            "Stn": {
+                                                "id": "db_8003200#81",
+                                                "name": "Kassel-Wilhelmshöhe",
+                                                "x": 9.446899,
+                                                "y": 51.313115
+                                            }
+                                        },
+                                        {
+                                            "dep": "2019-12-24T14:08:00",
+                                            "arr": "2019-12-24T14:06:00",
+                                            "Stn": {
+                                                "id": "db_8000128#81",
+                                                "name": "Göttingen",
+                                                "x": 9.926069,
+                                                "y": 51.536812
+                                            }
+                                        },
+                                        {
+                                            "dep": "2019-12-24T14:37:00",
+                                            "arr": "2019-12-24T14:36:00",
+                                            "Stn": {
+                                                "id": "db_8000169#81",
+                                                "name": "Hildesheim Hbf",
+                                                "x": 9.953495,
+                                                "y": 52.160627
+                                            }
+                                        },
+                                        {
+                                            "dep": "2019-12-24T15:02:00",
+                                            "arr": "2019-12-24T15:00:00",
+                                            "Stn": {
+                                                "id": "db_8000049#81",
+                                                "name": "Braunschweig Hbf",
+                                                "x": 10.540293,
+                                                "y": 52.252218
+                                            }
+                                        },
+                                        {
+                                            "arr": "2019-12-24T16:11:00",
+                                            "Stn": {
+                                                "id": "db_8010404#81",
+                                                "name": "Berlin-Spandau",
+                                                "x": 13.196902,
+                                                "y": 52.53465
+                                            }
+                                        },
+                                        {
+                                            "arr": "2019-12-24T16:26:00",
+                                            "Stn": {
+                                                "id": "db_8011160#81",
+                                                "name": "Berlin Hbf",
+                                                "x": 13.369549,
+                                                "y": 52.525589
+                                            }
+                                        }
+                                    ]
+                                },
+                                "Arr": {
+                                    "time": "2019-12-24T16:26:00",
+                                    "platform": "11",
+                                    "Stn": {
+                                        "id": "db_8011160#81",
+                                        "name": "Berlin Hbf",
+                                        "x": 13.369549,
+                                        "y": 52.525589
+                                    }
+                                }
+                            },
+                            {
+                                "mode": 20,
+                                "id": "R001634-C1-S3",
+                                "Dep": {
+                                    "time": "2019-12-24T16:26:00",
+                                    "Stn": {
+                                        "id": "db_8011160#81",
+                                        "name": "Berlin Hbf",
+                                        "x": 13.369549,
+                                        "y": 52.525589
+                                    },
+                                    "Transport": {
+                                        "mode": 20
+                                    }
+                                },
+                                "Journey": {
+                                    "duration": "PT8M",
+                                    "distance": 500
+                                },
+                                "Arr": {
+                                    "time": "2019-12-24T16:34:00",
+                                    "Stn": {
+                                        "id": "db_8089021#81",
+                                        "name": "Berlin Hbf (S-Bahn)",
+                                        "x": 13.369549,
+                                        "y": 52.525589
+                                    }
+                                }
+                            },
+                            {
+                                "mode": 4,
+                                "id": "R001634-C1-S4",
+                                "Dep": {
+                                    "time": "2019-12-24T16:35:00",
+                                    "platform": "15",
+                                    "Stn": {
+                                        "id": "db_8089021#81",
+                                        "name": "Berlin Hbf (S-Bahn)",
+                                        "x": 13.369549,
+                                        "y": 52.525589
+                                    },
+                                    "Transport": {
+                                        "mode": 4,
+                                        "dir": "Erkner (S)",
+                                        "name": "S3",
+                                        "At": {
+                                            "category": "S-Bahn",
+                                            "operator": "DB",
+                                            "color": "#0068B1"
+                                        }
+                                    },
+                                    "Freq": {
+                                        "min": 3,
+                                        "max": 10,
+                                        "AltDep": [
+                                            {
+                                                "time": "2019-12-24T16:38:00",
+                                                "Transport": {
+                                                    "mode": 4,
+                                                    "dir": "Ahrensfelde (S)",
+                                                    "name": "S7",
+                                                    "At": {
+                                                        "category": "S-Bahn",
+                                                        "operator": "DB",
+                                                        "color": "#7D6AAA"
+                                                    }
+                                                }
+                                            },
+                                            {
+                                                "time": "2019-12-24T16:41:00",
+                                                "Transport": {
+                                                    "mode": 4,
+                                                    "dir": "Strausberg Nord",
+                                                    "name": "S5",
+                                                    "At": {
+                                                        "category": "S-Bahn",
+                                                        "operator": "DB",
+                                                        "color": "#F27B26"
+                                                    }
+                                                }
+                                            },
+                                            {
+                                                "time": "2019-12-24T16:45:00",
+                                                "Transport": {
+                                                    "mode": 4,
+                                                    "dir": "Berlin-Schönefeld Flughafen",
+                                                    "name": "S9",
+                                                    "At": {
+                                                        "category": "S-Bahn",
+                                                        "operator": "DB",
+                                                        "color": "#953450"
+                                                    }
+                                                }
+                                            }
+                                        ]
+                                    }
+                                },
+                                "Journey": {
+                                    "duration": "PT4M",
+                                    "Stop": [
+                                        {
+                                            "dep": "2019-12-24T16:35:00",
+                                            "Stn": {
+                                                "id": "db_8089021#81",
+                                                "name": "Berlin Hbf (S-Bahn)",
+                                                "x": 13.369549,
+                                                "y": 52.525589
+                                            }
+                                        },
+                                        {
+                                            "dep": "2019-12-24T16:38:00",
+                                            "arr": "2019-12-24T16:37:00",
+                                            "Stn": {
+                                                "id": "db_8089066#81",
+                                                "name": "Berlin Friedrichstraße (S)",
+                                                "x": 13.386907,
+                                                "y": 52.520178
+                                            }
+                                        },
+                                        {
+                                            "dep": "2019-12-24T16:40:00",
+                                            "arr": "2019-12-24T16:39:00",
+                                            "Stn": {
+                                                "id": "db_8089017#81",
+                                                "name": "Berlin Hackescher Markt",
+                                                "x": 13.402368,
+                                                "y": 52.522623
+                                            }
+                                        }
+                                    ]
+                                },
+                                "Arr": {
+                                    "time": "2019-12-24T16:39:00",
+                                    "platform": "3",
+                                    "Stn": {
+                                        "id": "db_8089017#81",
+                                        "name": "Berlin Hackescher Markt",
+                                        "x": 13.402368,
+                                        "y": 52.522623
+                                    }
+                                }
+                            },
+                            {
+                                "mode": 20,
+                                "id": "R001634-C1-S5",
+                                "Dep": {
+                                    "time": "2019-12-24T16:39:00",
+                                    "Stn": {
+                                        "id": "db_8089017#81",
+                                        "name": "Berlin Hackescher Markt",
+                                        "x": 13.402368,
+                                        "y": 52.522623
+                                    },
+                                    "Transport": {
+                                        "mode": 20
+                                    }
+                                },
+                                "Journey": {
+                                    "duration": "PT3M",
+                                    "distance": 149
+                                },
+                                "Arr": {
+                                    "time": "2019-12-24T16:42:00",
+                                    "Addr": {
+                                        "x": 13.403411,
+                                        "y": 52.521436
+                                    }
+                                }
+                            }
+                        ]
+                    }
+                },
+                {
+                    "id": "R001634-C2",
+                    "duration": "PT5H25M",
+                    "transfers": 2,
+                    "Dep": {
+                        "time": "2019-12-24T11:20:00",
+                        "Addr": {
+                            "x": 8.276386,
+                            "y": 49.999252
+                        }
+                    },
+                    "Arr": {
+                        "time": "2019-12-24T16:45:00",
+                        "Addr": {
+                            "x": 13.403411,
+                            "y": 52.521436
+                        }
+                    },
+                    "Sections": {
+                        "Sec": [
+                            {
+                                "mode": 20,
+                                "id": "R001634-C2-S0",
+                                "Dep": {
+                                    "time": "2019-12-24T11:20:00",
+                                    "Addr": {
+                                        "x": 8.276386,
+                                        "y": 49.999252
+                                    },
+                                    "Transport": {
+                                        "mode": 20
+                                    }
+                                },
+                                "Journey": {
+                                    "duration": "PT19M",
+                                    "distance": 948
+                                },
+                                "Arr": {
+                                    "time": "2019-12-24T11:39:00",
+                                    "Stn": {
+                                        "id": "db_8000615#81",
+                                        "name": "Mainz-Kastel",
+                                        "x": 8.283173,
+                                        "y": 50.006578
+                                    }
+                                }
+                            },
+                            {
+                                "mode": 3,
+                                "id": "R001634-C2-S1",
+                                "Dep": {
+                                    "time": "2019-12-24T11:39:00",
+                                    "platform": "2",
+                                    "Stn": {
+                                        "id": "db_8000615#81",
+                                        "name": "Mainz-Kastel",
+                                        "x": 8.283173,
+                                        "y": 50.006578
+                                    },
+                                    "Transport": {
+                                        "mode": 3,
+                                        "dir": "Frankfurt(Main)Hbf",
+                                        "name": "VIA25013",
+                                        "At": {
+                                            "category": "VIAS GmbH",
+                                            "operator": "DB",
+                                            "color": "#EC1B2D"
+                                        }
+                                    },
+                                    "Freq": {
+                                        "min": 60,
+                                        "max": 60,
+                                        "AltDep": [
+                                            {
+                                                "time": "2019-12-24T12:39:00",
+                                                "Transport": {
+                                                    "mode": 3,
+                                                    "dir": "Frankfurt(Main)Hbf",
+                                                    "name": "VIA25015",
+                                                    "At": {
+                                                        "category": "VIAS GmbH",
+                                                        "operator": "DB",
+                                                        "color": "#EC1B2D"
+                                                    }
+                                                }
+                                            },
+                                            {
+                                                "time": "2019-12-24T13:39:00",
+                                                "Transport": {
+                                                    "mode": 3,
+                                                    "dir": "Frankfurt(Main)Hbf",
+                                                    "name": "VIA25017",
+                                                    "At": {
+                                                        "category": "VIAS GmbH",
+                                                        "operator": "DB",
+                                                        "color": "#EC1B2D"
+                                                    }
+                                                }
+                                            },
+                                            {
+                                                "time": "2019-12-24T14:39:00",
+                                                "Transport": {
+                                                    "mode": 3,
+                                                    "dir": "Frankfurt(Main)Hbf",
+                                                    "name": "VIA25019",
+                                                    "At": {
+                                                        "category": "VIAS GmbH",
+                                                        "operator": "DB",
+                                                        "color": "#EC1B2D"
+                                                    }
+                                                }
+                                            }
+                                        ]
+                                    }
+                                },
+                                "Journey": {
+                                    "duration": "PT26M",
+                                    "Stop": [
+                                        {
+                                            "dep": "2019-12-24T11:39:00",
+                                            "arr": "2019-12-24T11:38:00",
+                                            "Stn": {
+                                                "id": "db_8000615#81",
+                                                "name": "Mainz-Kastel",
+                                                "x": 8.283173,
+                                                "y": 50.006578
+                                            }
+                                        },
+                                        {
+                                            "dep": "2019-12-24T11:55:00",
+                                            "arr": "2019-12-24T11:54:00",
+                                            "Stn": {
+                                                "id": "db_8000106#81",
+                                                "name": "Frankfurt-Höchst",
+                                                "x": 8.542368,
+                                                "y": 50.102637
+                                            }
+                                        },
+                                        {
+                                            "arr": "2019-12-24T12:05:00",
+                                            "Stn": {
+                                                "id": "db_8000105#81",
+                                                "name": "Frankfurt(Main)Hbf",
+                                                "x": 8.663785,
+                                                "y": 50.107149
+                                            }
+                                        }
+                                    ]
+                                },
+                                "Arr": {
+                                    "time": "2019-12-24T12:05:00",
+                                    "platform": "23",
+                                    "Stn": {
+                                        "id": "db_8000105#81",
+                                        "name": "Frankfurt(Main)Hbf",
+                                        "x": 8.663785,
+                                        "y": 50.107149
+                                    }
+                                }
+                            },
+                            {
+                                "mode": 0,
+                                "id": "R001634-C2-S2",
+                                "Dep": {
+                                    "time": "2019-12-24T12:14:00",
+                                    "platform": "8",
+                                    "Stn": {
+                                        "id": "db_8000105#81",
+                                        "name": "Frankfurt(Main)Hbf",
+                                        "x": 8.663785,
+                                        "y": 50.107149
+                                    },
+                                    "Transport": {
+                                        "mode": 0,
+                                        "dir": "Berlin Gesundbrunnen",
+                                        "name": "ICE 690",
+                                        "At": {
+                                            "category": "Intercity-Express",
+                                            "operator": "DB",
+                                            "color": "#EC1B2D"
+                                        }
+                                    },
+                                    "Freq": {
+                                        "min": 12,
+                                        "max": 60,
+                                        "AltDep": [
+                                            {
+                                                "time": "2019-12-24T13:02:00",
+                                                "Transport": {
+                                                    "mode": 0,
+                                                    "dir": "Berlin Hbf (tief)",
+                                                    "name": "ICE 939",
+                                                    "At": {
+                                                        "category": "Intercity-Express",
+                                                        "operator": "DB",
+                                                        "color": "#EC1B2D"
+                                                    }
+                                                }
+                                            },
+                                            {
+                                                "time": "2019-12-24T13:14:00",
+                                                "Transport": {
+                                                    "mode": 0,
+                                                    "dir": "Berlin Ostbahnhof",
+                                                    "name": "ICE 370",
+                                                    "At": {
+                                                        "category": "Intercity-Express",
+                                                        "operator": "DB",
+                                                        "color": "#EC1B2D"
+                                                    }
+                                                }
+                                            },
+                                            {
+                                                "time": "2019-12-24T14:14:00",
+                                                "Transport": {
+                                                    "mode": 0,
+                                                    "dir": "Berlin Gesundbrunnen",
+                                                    "name": "ICE 598",
+                                                    "At": {
+                                                        "category": "Intercity-Express",
+                                                        "operator": "DB",
+                                                        "color": "#EC1B2D"
+                                                    }
+                                                }
+                                            }
+                                        ]
+                                    }
+                                },
+                                "Journey": {
+                                    "duration": "PT4H15M",
+                                    "Stop": [
+                                        {
+                                            "dep": "2019-12-24T12:14:00",
+                                            "arr": "2019-12-24T12:08:00",
+                                            "Stn": {
+                                                "id": "db_8000105#81",
+                                                "name": "Frankfurt(Main)Hbf",
+                                                "x": 8.663785,
+                                                "y": 50.107149
+                                            }
+                                        },
+                                        {
+                                            "dep": "2019-12-24T13:09:00",
+                                            "arr": "2019-12-24T13:07:00",
+                                            "Stn": {
+                                                "id": "db_8000115#81",
+                                                "name": "Fulda",
+                                                "x": 9.68398,
+                                                "y": 50.554722
+                                            }
+                                        },
+                                        {
+                                            "dep": "2019-12-24T14:02:00",
+                                            "arr": "2019-12-24T14:00:00",
+                                            "Stn": {
+                                                "id": "db_8010097#81",
+                                                "name": "Eisenach",
+                                                "x": 10.331986,
+                                                "y": 50.976919
+                                            }
+                                        },
+                                        {
+                                            "dep": "2019-12-24T14:28:00",
+                                            "arr": "2019-12-24T14:26:00",
+                                            "Stn": {
+                                                "id": "db_8010101#81",
+                                                "name": "Erfurt Hbf",
+                                                "x": 11.038502,
+                                                "y": 50.97255
+                                            }
+                                        },
+                                        {
+                                            "dep": "2019-12-24T15:16:00",
+                                            "arr": "2019-12-24T15:10:00",
+                                            "Stn": {
+                                                "id": "db_8010205#81",
+                                                "name": "Leipzig Hbf",
+                                                "x": 12.382066,
+                                                "y": 51.345467
+                                            }
+                                        },
+                                        {
+                                            "dep": "2019-12-24T15:48:00",
+                                            "arr": "2019-12-24T15:46:00",
+                                            "Stn": {
+                                                "id": "db_8010222#81",
+                                                "name": "Lutherstadt Wittenberg Hbf",
+                                                "x": 12.662286,
+                                                "y": 51.867813
+                                            }
+                                        },
+                                        {
+                                            "arr": "2019-12-24T16:22:00",
+                                            "Stn": {
+                                                "id": "db_8011113#81",
+                                                "name": "Berlin Südkreuz",
+                                                "x": 13.365315,
+                                                "y": 52.475043
+                                            }
+                                        },
+                                        {
+                                            "arr": "2019-12-24T16:29:00",
+                                            "Stn": {
+                                                "id": "db_8098160#81",
+                                                "name": "Berlin Hbf (tief)",
+                                                "x": 13.369549,
+                                                "y": 52.525589
+                                            }
+                                        }
+                                    ]
+                                },
+                                "Arr": {
+                                    "time": "2019-12-24T16:29:00",
+                                    "platform": "6",
+                                    "Stn": {
+                                        "id": "db_8098160#81",
+                                        "name": "Berlin Hbf (tief)",
+                                        "x": 13.369549,
+                                        "y": 52.525589
+                                    }
+                                }
+                            },
+                            {
+                                "mode": 20,
+                                "id": "R001634-C2-S3",
+                                "Dep": {
+                                    "time": "2019-12-24T16:29:00",
+                                    "Stn": {
+                                        "id": "db_8098160#81",
+                                        "name": "Berlin Hbf (tief)",
+                                        "x": 13.369549,
+                                        "y": 52.525589
+                                    },
+                                    "Transport": {
+                                        "mode": 20
+                                    }
+                                },
+                                "Journey": {
+                                    "duration": "PT9M",
+                                    "distance": 500
+                                },
+                                "Arr": {
+                                    "time": "2019-12-24T16:38:00",
+                                    "Stn": {
+                                        "id": "db_8089021#81",
+                                        "name": "Berlin Hbf (S-Bahn)",
+                                        "x": 13.369549,
+                                        "y": 52.525589
+                                    }
+                                }
+                            },
+                            {
+                                "mode": 4,
+                                "id": "R001634-C2-S4",
+                                "Dep": {
+                                    "time": "2019-12-24T16:38:00",
+                                    "platform": "15",
+                                    "Stn": {
+                                        "id": "db_8089021#81",
+                                        "name": "Berlin Hbf (S-Bahn)",
+                                        "x": 13.369549,
+                                        "y": 52.525589
+                                    },
+                                    "Transport": {
+                                        "mode": 4,
+                                        "dir": "Ahrensfelde (S)",
+                                        "name": "S7",
+                                        "At": {
+                                            "category": "S-Bahn",
+                                            "operator": "DB",
+                                            "color": "#7D6AAA"
+                                        }
+                                    },
+                                    "Freq": {
+                                        "min": 3,
+                                        "max": 10,
+                                        "AltDep": [
+                                            {
+                                                "time": "2019-12-24T16:41:00",
+                                                "Transport": {
+                                                    "mode": 4,
+                                                    "dir": "Strausberg Nord",
+                                                    "name": "S5",
+                                                    "At": {
+                                                        "category": "S-Bahn",
+                                                        "operator": "DB",
+                                                        "color": "#F27B26"
+                                                    }
+                                                }
+                                            },
+                                            {
+                                                "time": "2019-12-24T16:45:00",
+                                                "Transport": {
+                                                    "mode": 4,
+                                                    "dir": "Berlin-Schönefeld Flughafen",
+                                                    "name": "S9",
+                                                    "At": {
+                                                        "category": "S-Bahn",
+                                                        "operator": "DB",
+                                                        "color": "#953450"
+                                                    }
+                                                }
+                                            },
+                                            {
+                                                "time": "2019-12-24T16:48:00",
+                                                "Transport": {
+                                                    "mode": 4,
+                                                    "dir": "Berlin Ostbahnhof (S)",
+                                                    "name": "S7",
+                                                    "At": {
+                                                        "category": "S-Bahn",
+                                                        "operator": "DB",
+                                                        "color": "#7D6AAA"
+                                                    }
+                                                }
+                                            }
+                                        ]
+                                    }
+                                },
+                                "Journey": {
+                                    "duration": "PT4M",
+                                    "Stop": [
+                                        {
+                                            "dep": "2019-12-24T16:38:00",
+                                            "Stn": {
+                                                "id": "db_8089021#81",
+                                                "name": "Berlin Hbf (S-Bahn)",
+                                                "x": 13.369549,
+                                                "y": 52.525589
+                                            }
+                                        },
+                                        {
+                                            "dep": "2019-12-24T16:41:00",
+                                            "arr": "2019-12-24T16:40:00",
+                                            "Stn": {
+                                                "id": "db_8089066#81",
+                                                "name": "Berlin Friedrichstraße (S)",
+                                                "x": 13.386907,
+                                                "y": 52.520178
+                                            }
+                                        },
+                                        {
+                                            "dep": "2019-12-24T16:43:00",
+                                            "arr": "2019-12-24T16:42:00",
+                                            "Stn": {
+                                                "id": "db_8089017#81",
+                                                "name": "Berlin Hackescher Markt",
+                                                "x": 13.402368,
+                                                "y": 52.522623
+                                            }
+                                        }
+                                    ]
+                                },
+                                "Arr": {
+                                    "time": "2019-12-24T16:42:00",
+                                    "platform": "3",
+                                    "Stn": {
+                                        "id": "db_8089017#81",
+                                        "name": "Berlin Hackescher Markt",
+                                        "x": 13.402368,
+                                        "y": 52.522623
+                                    }
+                                }
+                            },
+                            {
+                                "mode": 20,
+                                "id": "R001634-C2-S5",
+                                "Dep": {
+                                    "time": "2019-12-24T16:42:00",
+                                    "Stn": {
+                                        "id": "db_8089017#81",
+                                        "name": "Berlin Hackescher Markt",
+                                        "x": 13.402368,
+                                        "y": 52.522623
+                                    },
+                                    "Transport": {
+                                        "mode": 20
+                                    }
+                                },
+                                "Journey": {
+                                    "duration": "PT3M",
+                                    "distance": 149
+                                },
+                                "Arr": {
+                                    "time": "2019-12-24T16:45:00",
+                                    "Addr": {
+                                        "x": 13.403411,
+                                        "y": 52.521436
+                                    }
+                                }
+                            }
+                        ]
+                    }
+                },
+                {
+                    "id": "R001634-C3",
+                    "duration": "PT5H18M",
+                    "transfers": 3,
+                    "Dep": {
+                        "time": "2019-12-24T11:24:00",
+                        "Addr": {
+                            "x": 8.276386,
+                            "y": 49.999252
+                        }
+                    },
+                    "Arr": {
+                        "time": "2019-12-24T16:42:00",
+                        "Addr": {
+                            "x": 13.403411,
+                            "y": 52.521436
+                        }
+                    },
+                    "Sections": {
+                        "Sec": [
+                            {
+                                "mode": 20,
+                                "id": "R001634-C3-S0",
+                                "Dep": {
+                                    "time": "2019-12-24T11:24:00",
+                                    "Addr": {
+                                        "x": 8.276386,
+                                        "y": 49.999252
+                                    },
+                                    "Transport": {
+                                        "mode": 20
+                                    }
+                                },
+                                "Journey": {
+                                    "duration": "PT1M",
+                                    "distance": 47
+                                },
+                                "Arr": {
+                                    "time": "2019-12-24T11:25:00",
+                                    "Stn": {
+                                        "id": "db_118065#81",
+                                        "name": "Fischtor",
+                                        "x": 8.277034,
+                                        "y": 49.999162
+                                    }
+                                }
+                            },
+                            {
+                                "mode": 5,
+                                "id": "R001634-C3-S1",
+                                "Dep": {
+                                    "time": "2019-12-24T11:25:00",
+                                    "Stn": {
+                                        "id": "db_118065#81",
+                                        "name": "Fischtor",
+                                        "x": 8.277034,
+                                        "y": 49.999162
+                                    },
+                                    "Transport": {
+                                        "mode": 5,
+                                        "dir": "Mombach Am Polygon",
+                                        "name": "61",
+                                        "At": {
+                                            "category": "Bus",
+                                            "operator": "DB"
+                                        }
+                                    },
+                                    "Freq": {
+                                        "min": 7,
+                                        "max": 8,
+                                        "AltDep": [
+                                            {
+                                                "time": "2019-12-24T11:33:00",
+                                                "Transport": {
+                                                    "mode": 5,
+                                                    "dir": "Mombacher Tor",
+                                                    "name": "60",
+                                                    "At": {
+                                                        "category": "Bus",
+                                                        "operator": "DB"
+                                                    }
+                                                }
+                                            },
+                                            {
+                                                "time": "2019-12-24T11:40:00",
+                                                "Transport": {
+                                                    "mode": 5,
+                                                    "dir": "Golfplatz",
+                                                    "name": "61",
+                                                    "At": {
+                                                        "category": "Bus",
+                                                        "operator": "DB"
+                                                    }
+                                                }
+                                            },
+                                            {
+                                                "time": "2019-12-24T11:48:00",
+                                                "Transport": {
+                                                    "mode": 5,
+                                                    "dir": "Mombacher Tor",
+                                                    "name": "63",
+                                                    "At": {
+                                                        "category": "Bus",
+                                                        "operator": "DB"
+                                                    }
+                                                }
+                                            }
+                                        ]
+                                    }
+                                },
+                                "Journey": {
+                                    "duration": "PT10M",
+                                    "Stop": [
+                                        {
+                                            "dep": "2019-12-24T11:25:00",
+                                            "Stn": {
+                                                "id": "db_118065#81",
+                                                "name": "Fischtor",
+                                                "x": 8.277034,
+                                                "y": 49.999162
+                                            }
+                                        },
+                                        {
+                                            "dep": "2019-12-24T11:27:00",
+                                            "Stn": {
+                                                "id": "db_405371#81",
+                                                "name": "Rheingoldhalle/Rathaus",
+                                                "x": 8.275559,
+                                                "y": 50.001418
+                                            }
+                                        },
+                                        {
+                                            "dep": "2019-12-24T11:29:00",
+                                            "Stn": {
+                                                "id": "db_405041#81",
+                                                "name": "Höfchen/Listmann",
+                                                "x": 8.272063,
+                                                "y": 49.999513
+                                            }
+                                        },
+                                        {
+                                            "dep": "2019-12-24T11:31:00",
+                                            "Stn": {
+                                                "id": "db_405372#81",
+                                                "name": "Schillerplatz",
+                                                "x": 8.266822,
+                                                "y": 49.998713
+                                            }
+                                        },
+                                        {
+                                            "dep": "2019-12-24T11:33:00",
+                                            "Stn": {
+                                                "id": "db_405373#81",
+                                                "name": "Münsterplatz",
+                                                "x": 8.263703,
+                                                "y": 50.000304
+                                            }
+                                        },
+                                        {
+                                            "dep": "2019-12-24T11:35:00",
+                                            "Stn": {
+                                                "id": "db_518921#81",
+                                                "name": "Hauptbahnhof",
+                                                "x": 8.259774,
+                                                "y": 50.001751
+                                            }
+                                        }
+                                    ]
+                                },
+                                "Arr": {
+                                    "time": "2019-12-24T11:35:00",
+                                    "Stn": {
+                                        "id": "db_518921#81",
+                                        "name": "Hauptbahnhof",
+                                        "x": 8.259774,
+                                        "y": 50.001751
+                                    }
+                                }
+                            },
+                            {
+                                "mode": 20,
+                                "id": "R001634-C3-S2",
+                                "Dep": {
+                                    "time": "2019-12-24T11:35:00",
+                                    "Stn": {
+                                        "id": "db_518921#81",
+                                        "name": "Hauptbahnhof",
+                                        "x": 8.259774,
+                                        "y": 50.001751
+                                    },
+                                    "Transport": {
+                                        "mode": 20
+                                    }
+                                },
+                                "Journey": {
+                                    "duration": "PT5M",
+                                    "distance": 603
+                                },
+                                "Arr": {
+                                    "time": "2019-12-24T11:40:00",
+                                    "Stn": {
+                                        "id": "db_8000240#81",
+                                        "name": "Mainz Hbf",
+                                        "x": 8.258723,
+                                        "y": 50.001113
+                                    }
+                                }
+                            },
+                            {
+                                "mode": 0,
+                                "id": "R001634-C3-S3",
+                                "Dep": {
+                                    "time": "2019-12-24T11:42:00",
+                                    "platform": "4a/b",
+                                    "Stn": {
+                                        "id": "db_8000240#81",
+                                        "name": "Mainz Hbf",
+                                        "x": 8.258723,
+                                        "y": 50.001113
+                                    },
+                                    "Transport": {
+                                        "mode": 0,
+                                        "dir": "Wien Hbf",
+                                        "name": "ICE 27",
+                                        "At": {
+                                            "category": "Intercity-Express",
+                                            "operator": "DB",
+                                            "color": "#EC1B2D"
+                                        }
+                                    },
+                                    "Freq": {
+                                        "min": 59,
+                                        "max": 61,
+                                        "AltDep": [
+                                            {
+                                                "time": "2019-12-24T12:43:00",
+                                                "Transport": {
+                                                    "mode": 0,
+                                                    "dir": "Dresden Hbf",
+                                                    "name": "ICE 1651",
+                                                    "At": {
+                                                        "category": "Intercity-Express",
+                                                        "operator": "DB",
+                                                        "color": "#EC1B2D"
+                                                    }
+                                                }
+                                            },
+                                            {
+                                                "time": "2019-12-24T13:42:00",
+                                                "Transport": {
+                                                    "mode": 0,
+                                                    "dir": "Frankfurt(Main)Hbf",
+                                                    "name": "ICE 923",
+                                                    "At": {
+                                                        "category": "Intercity-Express",
+                                                        "operator": "DB",
+                                                        "color": "#EC1B2D"
+                                                    }
+                                                }
+                                            },
+                                            {
+                                                "time": "2019-12-24T14:43:00",
+                                                "Transport": {
+                                                    "mode": 0,
+                                                    "dir": "Dresden Hbf",
+                                                    "name": "ICE 1653",
+                                                    "At": {
+                                                        "category": "Intercity-Express",
+                                                        "operator": "DB",
+                                                        "color": "#EC1B2D"
+                                                    }
+                                                }
+                                            }
+                                        ]
+                                    }
+                                },
+                                "Journey": {
+                                    "duration": "PT17M",
+                                    "Stop": [
+                                        {
+                                            "dep": "2019-12-24T11:42:00",
+                                            "arr": "2019-12-24T11:39:00",
+                                            "Stn": {
+                                                "id": "db_8000240#81",
+                                                "name": "Mainz Hbf",
+                                                "x": 8.258723,
+                                                "y": 50.001113
+                                            }
+                                        },
+                                        {
+                                            "dep": "2019-12-24T12:02:00",
+                                            "arr": "2019-12-24T11:59:00",
+                                            "Stn": {
+                                                "id": "db_8070003#81",
+                                                "name": "Frankfurt(M) Flughafen Fernbf",
+                                                "x": 8.570181,
+                                                "y": 50.053169
+                                            }
+                                        }
+                                    ]
+                                },
+                                "Arr": {
+                                    "time": "2019-12-24T11:59:00",
+                                    "platform": "Fern 5",
+                                    "Stn": {
+                                        "id": "db_8070003#81",
+                                        "name": "Frankfurt(M) Flughafen Fernbf",
+                                        "x": 8.570181,
+                                        "y": 50.053169
+                                    }
+                                }
+                            },
+                            {
+                                "mode": 0,
+                                "id": "R001634-C3-S4",
+                                "Dep": {
+                                    "time": "2019-12-24T12:09:00",
+                                    "platform": "Fern 4",
+                                    "Stn": {
+                                        "id": "db_8070003#81",
+                                        "name": "Frankfurt(M) Flughafen Fernbf",
+                                        "x": 8.570181,
+                                        "y": 50.053169
+                                    },
+                                    "Transport": {
+                                        "mode": 0,
+                                        "dir": "Berlin Ostbahnhof",
+                                        "name": "ICE 798",
+                                        "At": {
+                                            "category": "Intercity-Express",
+                                            "operator": "DB",
+                                            "color": "#EC1B2D"
+                                        }
+                                    },
+                                    "Freq": {
+                                        "min": 120,
+                                        "max": 120,
+                                        "AltDep": [
+                                            {
+                                                "time": "2019-12-24T14:09:00",
+                                                "Transport": {
+                                                    "mode": 0,
+                                                    "dir": "Berlin Ostbahnhof",
+                                                    "name": "ICE 1196",
+                                                    "At": {
+                                                        "category": "Intercity-Express",
+                                                        "operator": "DB",
+                                                        "color": "#EC1B2D"
+                                                    }
+                                                }
+                                            },
+                                            {
+                                                "time": "2019-12-24T16:09:00",
+                                                "Transport": {
+                                                    "mode": 0,
+                                                    "dir": "Berlin Ostbahnhof",
+                                                    "name": "ICE 794",
+                                                    "At": {
+                                                        "category": "Intercity-Express",
+                                                        "operator": "DB",
+                                                        "color": "#EC1B2D"
+                                                    }
+                                                }
+                                            }
+                                        ]
+                                    }
+                                },
+                                "Journey": {
+                                    "duration": "PT4H17M",
+                                    "Stop": [
+                                        {
+                                            "dep": "2019-12-24T12:09:00",
+                                            "Stn": {
+                                                "id": "db_8070003#81",
+                                                "name": "Frankfurt(M) Flughafen Fernbf",
+                                                "x": 8.570181,
+                                                "y": 50.053169
+                                            }
+                                        },
+                                        {
+                                            "dep": "2019-12-24T12:20:00",
+                                            "arr": "2019-12-24T12:18:00",
+                                            "Stn": {
+                                                "id": "db_8002041#81",
+                                                "name": "Frankfurt(Main)Süd",
+                                                "x": 8.686456,
+                                                "y": 50.099365
+                                            }
+                                        },
+                                        {
+                                            "dep": "2019-12-24T13:13:00",
+                                            "arr": "2019-12-24T13:11:00",
+                                            "Stn": {
+                                                "id": "db_8000115#81",
+                                                "name": "Fulda",
+                                                "x": 9.68398,
+                                                "y": 50.554722
+                                            }
+                                        },
+                                        {
+                                            "dep": "2019-12-24T13:47:00",
+                                            "arr": "2019-12-24T13:45:00",
+                                            "Stn": {
+                                                "id": "db_8003200#81",
+                                                "name": "Kassel-Wilhelmshöhe",
+                                                "x": 9.446899,
+                                                "y": 51.313115
+                                            }
+                                        },
+                                        {
+                                            "dep": "2019-12-24T14:08:00",
+                                            "arr": "2019-12-24T14:06:00",
+                                            "Stn": {
+                                                "id": "db_8000128#81",
+                                                "name": "Göttingen",
+                                                "x": 9.926069,
+                                                "y": 51.536812
+                                            }
+                                        },
+                                        {
+                                            "dep": "2019-12-24T14:37:00",
+                                            "arr": "2019-12-24T14:36:00",
+                                            "Stn": {
+                                                "id": "db_8000169#81",
+                                                "name": "Hildesheim Hbf",
+                                                "x": 9.953495,
+                                                "y": 52.160627
+                                            }
+                                        },
+                                        {
+                                            "dep": "2019-12-24T15:02:00",
+                                            "arr": "2019-12-24T15:00:00",
+                                            "Stn": {
+                                                "id": "db_8000049#81",
+                                                "name": "Braunschweig Hbf",
+                                                "x": 10.540293,
+                                                "y": 52.252218
+                                            }
+                                        },
+                                        {
+                                            "arr": "2019-12-24T16:11:00",
+                                            "Stn": {
+                                                "id": "db_8010404#81",
+                                                "name": "Berlin-Spandau",
+                                                "x": 13.196902,
+                                                "y": 52.53465
+                                            }
+                                        },
+                                        {
+                                            "arr": "2019-12-24T16:26:00",
+                                            "Stn": {
+                                                "id": "db_8011160#81",
+                                                "name": "Berlin Hbf",
+                                                "x": 13.369549,
+                                                "y": 52.525589
+                                            }
+                                        }
+                                    ]
+                                },
+                                "Arr": {
+                                    "time": "2019-12-24T16:26:00",
+                                    "platform": "11",
+                                    "Stn": {
+                                        "id": "db_8011160#81",
+                                        "name": "Berlin Hbf",
+                                        "x": 13.369549,
+                                        "y": 52.525589
+                                    }
+                                }
+                            },
+                            {
+                                "mode": 20,
+                                "id": "R001634-C3-S5",
+                                "Dep": {
+                                    "time": "2019-12-24T16:26:00",
+                                    "Stn": {
+                                        "id": "db_8011160#81",
+                                        "name": "Berlin Hbf",
+                                        "x": 13.369549,
+                                        "y": 52.525589
+                                    },
+                                    "Transport": {
+                                        "mode": 20
+                                    }
+                                },
+                                "Journey": {
+                                    "duration": "PT8M",
+                                    "distance": 500
+                                },
+                                "Arr": {
+                                    "time": "2019-12-24T16:34:00",
+                                    "Stn": {
+                                        "id": "db_8089021#81",
+                                        "name": "Berlin Hbf (S-Bahn)",
+                                        "x": 13.369549,
+                                        "y": 52.525589
+                                    }
+                                }
+                            },
+                            {
+                                "mode": 4,
+                                "id": "R001634-C3-S6",
+                                "Dep": {
+                                    "time": "2019-12-24T16:35:00",
+                                    "platform": "15",
+                                    "Stn": {
+                                        "id": "db_8089021#81",
+                                        "name": "Berlin Hbf (S-Bahn)",
+                                        "x": 13.369549,
+                                        "y": 52.525589
+                                    },
+                                    "Transport": {
+                                        "mode": 4,
+                                        "dir": "Erkner (S)",
+                                        "name": "S3",
+                                        "At": {
+                                            "category": "S-Bahn",
+                                            "operator": "DB",
+                                            "color": "#0068B1"
+                                        }
+                                    },
+                                    "Freq": {
+                                        "min": 3,
+                                        "max": 10,
+                                        "AltDep": [
+                                            {
+                                                "time": "2019-12-24T16:38:00",
+                                                "Transport": {
+                                                    "mode": 4,
+                                                    "dir": "Ahrensfelde (S)",
+                                                    "name": "S7",
+                                                    "At": {
+                                                        "category": "S-Bahn",
+                                                        "operator": "DB",
+                                                        "color": "#7D6AAA"
+                                                    }
+                                                }
+                                            },
+                                            {
+                                                "time": "2019-12-24T16:41:00",
+                                                "Transport": {
+                                                    "mode": 4,
+                                                    "dir": "Strausberg Nord",
+                                                    "name": "S5",
+                                                    "At": {
+                                                        "category": "S-Bahn",
+                                                        "operator": "DB",
+                                                        "color": "#F27B26"
+                                                    }
+                                                }
+                                            },
+                                            {
+                                                "time": "2019-12-24T16:45:00",
+                                                "Transport": {
+                                                    "mode": 4,
+                                                    "dir": "Berlin-Schönefeld Flughafen",
+                                                    "name": "S9",
+                                                    "At": {
+                                                        "category": "S-Bahn",
+                                                        "operator": "DB",
+                                                        "color": "#953450"
+                                                    }
+                                                }
+                                            }
+                                        ]
+                                    }
+                                },
+                                "Journey": {
+                                    "duration": "PT4M",
+                                    "Stop": [
+                                        {
+                                            "dep": "2019-12-24T16:35:00",
+                                            "Stn": {
+                                                "id": "db_8089021#81",
+                                                "name": "Berlin Hbf (S-Bahn)",
+                                                "x": 13.369549,
+                                                "y": 52.525589
+                                            }
+                                        },
+                                        {
+                                            "dep": "2019-12-24T16:38:00",
+                                            "arr": "2019-12-24T16:37:00",
+                                            "Stn": {
+                                                "id": "db_8089066#81",
+                                                "name": "Berlin Friedrichstraße (S)",
+                                                "x": 13.386907,
+                                                "y": 52.520178
+                                            }
+                                        },
+                                        {
+                                            "dep": "2019-12-24T16:40:00",
+                                            "arr": "2019-12-24T16:39:00",
+                                            "Stn": {
+                                                "id": "db_8089017#81",
+                                                "name": "Berlin Hackescher Markt",
+                                                "x": 13.402368,
+                                                "y": 52.522623
+                                            }
+                                        }
+                                    ]
+                                },
+                                "Arr": {
+                                    "time": "2019-12-24T16:39:00",
+                                    "platform": "3",
+                                    "Stn": {
+                                        "id": "db_8089017#81",
+                                        "name": "Berlin Hackescher Markt",
+                                        "x": 13.402368,
+                                        "y": 52.522623
+                                    }
+                                }
+                            },
+                            {
+                                "mode": 20,
+                                "id": "R001634-C3-S7",
+                                "Dep": {
+                                    "time": "2019-12-24T16:39:00",
+                                    "Stn": {
+                                        "id": "db_8089017#81",
+                                        "name": "Berlin Hackescher Markt",
+                                        "x": 13.402368,
+                                        "y": 52.522623
+                                    },
+                                    "Transport": {
+                                        "mode": 20
+                                    }
+                                },
+                                "Journey": {
+                                    "duration": "PT3M",
+                                    "distance": 149
+                                },
+                                "Arr": {
+                                    "time": "2019-12-24T16:42:00",
+                                    "Addr": {
+                                        "x": 13.403411,
+                                        "y": 52.521436
+                                    }
+                                }
+                            }
+                        ]
+                    }
+                },
+                {
+                    "id": "R001634-C4",
+                    "duration": "PT5H17M",
+                    "transfers": 4,
+                    "Dep": {
+                        "time": "2019-12-24T11:25:00",
+                        "Addr": {
+                            "x": 8.276386,
+                            "y": 49.999252
+                        }
+                    },
+                    "Arr": {
+                        "time": "2019-12-24T16:42:00",
+                        "Addr": {
+                            "x": 13.403411,
+                            "y": 52.521436
+                        }
+                    },
+                    "Sections": {
+                        "Sec": [
+                            {
+                                "mode": 20,
+                                "id": "R001634-C4-S0",
+                                "Dep": {
+                                    "time": "2019-12-24T11:25:00",
+                                    "Addr": {
+                                        "x": 8.276386,
+                                        "y": 49.999252
+                                    },
+                                    "Transport": {
+                                        "mode": 20
+                                    }
+                                },
+                                "Journey": {
+                                    "duration": "PT5M",
+                                    "distance": 248
+                                },
+                                "Arr": {
+                                    "time": "2019-12-24T11:30:00",
+                                    "Stn": {
+                                        "id": "db_405371#81",
+                                        "name": "Rheingoldhalle/Rathaus",
+                                        "x": 8.275559,
+                                        "y": 50.001418
+                                    }
+                                }
+                            },
+                            {
+                                "mode": 5,
+                                "id": "R001634-C4-S1",
+                                "Dep": {
+                                    "time": "2019-12-24T11:30:00",
+                                    "Stn": {
+                                        "id": "db_405371#81",
+                                        "name": "Rheingoldhalle/Rathaus",
+                                        "x": 8.275559,
+                                        "y": 50.001418
+                                    },
+                                    "Transport": {
+                                        "mode": 5,
+                                        "dir": "Altenwohnheim",
+                                        "name": "68",
+                                        "At": {
+                                            "category": "Bus",
+                                            "operator": "DB"
+                                        }
+                                    },
+                                    "Freq": {
+                                        "min": 3,
+                                        "max": 12,
+                                        "AltDep": [
+                                            {
+                                                "time": "2019-12-24T11:34:00",
+                                                "Transport": {
+                                                    "mode": 5,
+                                                    "dir": "Treburer Straße",
+                                                    "name": "58",
+                                                    "At": {
+                                                        "category": "Bus",
+                                                        "operator": "DB"
+                                                    }
+                                                }
+                                            },
+                                            {
+                                                "time": "2019-12-24T11:46:00",
+                                                "Transport": {
+                                                    "mode": 5,
+                                                    "dir": "Mainz-Kastel Krautgärten",
+                                                    "name": "57",
+                                                    "At": {
+                                                        "category": "Bus",
+                                                        "operator": "DB"
+                                                    }
+                                                }
+                                            },
+                                            {
+                                                "time": "2019-12-24T11:49:00",
+                                                "Transport": {
+                                                    "mode": 5,
+                                                    "dir": "Ginsheim Friedr.-Ebert-Platz",
+                                                    "name": "56",
+                                                    "At": {
+                                                        "category": "Bus",
+                                                        "operator": "DB"
+                                                    }
+                                                }
+                                            }
+                                        ]
+                                    }
+                                },
+                                "Journey": {
+                                    "duration": "PT4M",
+                                    "Stop": [
+                                        {
+                                            "dep": "2019-12-24T11:30:00",
+                                            "Stn": {
+                                                "id": "db_405371#81",
+                                                "name": "Rheingoldhalle/Rathaus",
+                                                "x": 8.275559,
+                                                "y": 50.001418
+                                            }
+                                        },
+                                        {
+                                            "dep": "2019-12-24T11:31:00",
+                                            "Stn": {
+                                                "id": "db_405181#81",
+                                                "name": "Brückenplatz",
+                                                "x": 8.274256,
+                                                "y": 50.00309
+                                            }
+                                        },
+                                        {
+                                            "dep": "2019-12-24T11:33:00",
+                                            "Stn": {
+                                                "id": "db_408022#81",
+                                                "name": "Mainz-Kastel Brückenkopf",
+                                                "x": 8.280189,
+                                                "y": 50.008061
+                                            }
+                                        },
+                                        {
+                                            "dep": "2019-12-24T11:34:00",
+                                            "Stn": {
+                                                "id": "db_405184#81",
+                                                "name": "Mainz-Kastel Bahnhof",
+                                                "x": 8.283784,
+                                                "y": 50.006929
+                                            }
+                                        }
+                                    ]
+                                },
+                                "Arr": {
+                                    "time": "2019-12-24T11:34:00",
+                                    "Stn": {
+                                        "id": "db_405184#81",
+                                        "name": "Mainz-Kastel Bahnhof",
+                                        "x": 8.283784,
+                                        "y": 50.006929
+                                    }
+                                }
+                            },
+                            {
+                                "mode": 20,
+                                "id": "R001634-C4-S2",
+                                "Dep": {
+                                    "time": "2019-12-24T11:34:00",
+                                    "Stn": {
+                                        "id": "db_405184#81",
+                                        "name": "Mainz-Kastel Bahnhof",
+                                        "x": 8.283784,
+                                        "y": 50.006929
+                                    },
+                                    "Transport": {
+                                        "mode": 20
+                                    }
+                                },
+                                "Journey": {
+                                    "duration": "PT3M",
+                                    "distance": 559
+                                },
+                                "Arr": {
+                                    "time": "2019-12-24T11:37:00",
+                                    "Stn": {
+                                        "id": "db_8000615#81",
+                                        "name": "Mainz-Kastel",
+                                        "x": 8.283173,
+                                        "y": 50.006578
+                                    }
+                                }
+                            },
+                            {
+                                "mode": 3,
+                                "id": "R001634-C4-S3",
+                                "Dep": {
+                                    "time": "2019-12-24T11:39:00",
+                                    "platform": "2",
+                                    "Stn": {
+                                        "id": "db_8000615#81",
+                                        "name": "Mainz-Kastel",
+                                        "x": 8.283173,
+                                        "y": 50.006578
+                                    },
+                                    "Transport": {
+                                        "mode": 3,
+                                        "dir": "Frankfurt(Main)Hbf",
+                                        "name": "VIA25013",
+                                        "At": {
+                                            "category": "VIAS GmbH",
+                                            "operator": "DB",
+                                            "color": "#EC1B2D"
+                                        }
+                                    },
+                                    "Freq": {
+                                        "min": 60,
+                                        "max": 60,
+                                        "AltDep": [
+                                            {
+                                                "time": "2019-12-24T12:39:00",
+                                                "Transport": {
+                                                    "mode": 3,
+                                                    "dir": "Frankfurt(Main)Hbf",
+                                                    "name": "VIA25015",
+                                                    "At": {
+                                                        "category": "VIAS GmbH",
+                                                        "operator": "DB",
+                                                        "color": "#EC1B2D"
+                                                    }
+                                                }
+                                            },
+                                            {
+                                                "time": "2019-12-24T13:39:00",
+                                                "Transport": {
+                                                    "mode": 3,
+                                                    "dir": "Frankfurt(Main)Hbf",
+                                                    "name": "VIA25017",
+                                                    "At": {
+                                                        "category": "VIAS GmbH",
+                                                        "operator": "DB",
+                                                        "color": "#EC1B2D"
+                                                    }
+                                                }
+                                            },
+                                            {
+                                                "time": "2019-12-24T14:39:00",
+                                                "Transport": {
+                                                    "mode": 3,
+                                                    "dir": "Frankfurt(Main)Hbf",
+                                                    "name": "VIA25019",
+                                                    "At": {
+                                                        "category": "VIAS GmbH",
+                                                        "operator": "DB",
+                                                        "color": "#EC1B2D"
+                                                    }
+                                                }
+                                            }
+                                        ]
+                                    }
+                                },
+                                "Journey": {
+                                    "duration": "PT26M",
+                                    "Stop": [
+                                        {
+                                            "dep": "2019-12-24T11:39:00",
+                                            "arr": "2019-12-24T11:38:00",
+                                            "Stn": {
+                                                "id": "db_8000615#81",
+                                                "name": "Mainz-Kastel",
+                                                "x": 8.283173,
+                                                "y": 50.006578
+                                            }
+                                        },
+                                        {
+                                            "dep": "2019-12-24T11:55:00",
+                                            "arr": "2019-12-24T11:54:00",
+                                            "Stn": {
+                                                "id": "db_8000106#81",
+                                                "name": "Frankfurt-Höchst",
+                                                "x": 8.542368,
+                                                "y": 50.102637
+                                            }
+                                        },
+                                        {
+                                            "arr": "2019-12-24T12:05:00",
+                                            "Stn": {
+                                                "id": "db_8000105#81",
+                                                "name": "Frankfurt(Main)Hbf",
+                                                "x": 8.663785,
+                                                "y": 50.107149
+                                            }
+                                        }
+                                    ]
+                                },
+                                "Arr": {
+                                    "time": "2019-12-24T12:05:00",
+                                    "platform": "23",
+                                    "Stn": {
+                                        "id": "db_8000105#81",
+                                        "name": "Frankfurt(Main)Hbf",
+                                        "x": 8.663785,
+                                        "y": 50.107149
+                                    }
+                                }
+                            },
+                            {
+                                "mode": 0,
+                                "id": "R001634-C4-S4",
+                                "Dep": {
+                                    "time": "2019-12-24T12:14:00",
+                                    "platform": "8",
+                                    "Stn": {
+                                        "id": "db_8000105#81",
+                                        "name": "Frankfurt(Main)Hbf",
+                                        "x": 8.663785,
+                                        "y": 50.107149
+                                    },
+                                    "Transport": {
+                                        "mode": 0,
+                                        "dir": "Berlin Gesundbrunnen",
+                                        "name": "ICE 690",
+                                        "At": {
+                                            "category": "Intercity-Express",
+                                            "operator": "DB",
+                                            "color": "#EC1B2D"
+                                        }
+                                    },
+                                    "Freq": {
+                                        "min": 17,
+                                        "max": 66,
+                                        "AltDep": [
+                                            {
+                                                "time": "2019-12-24T13:02:00",
+                                                "Transport": {
+                                                    "mode": 0,
+                                                    "dir": "Berlin Hbf (tief)",
+                                                    "name": "ICE 939",
+                                                    "At": {
+                                                        "category": "Intercity-Express",
+                                                        "operator": "DB",
+                                                        "color": "#EC1B2D"
+                                                    }
+                                                }
+                                            },
+                                            {
+                                                "time": "2019-12-24T13:19:00",
+                                                "Transport": {
+                                                    "mode": 0,
+                                                    "dir": "Dresden Hbf",
+                                                    "name": "ICE 1651",
+                                                    "At": {
+                                                        "category": "Intercity-Express",
+                                                        "operator": "DB",
+                                                        "color": "#EC1B2D"
+                                                    }
+                                                }
+                                            },
+                                            {
+                                                "time": "2019-12-24T14:14:00",
+                                                "Transport": {
+                                                    "mode": 0,
+                                                    "dir": "Berlin Gesundbrunnen",
+                                                    "name": "ICE 598",
+                                                    "At": {
+                                                        "category": "Intercity-Express",
+                                                        "operator": "DB",
+                                                        "color": "#EC1B2D"
+                                                    }
+                                                }
+                                            }
+                                        ]
+                                    }
+                                },
+                                "Journey": {
+                                    "duration": "PT2H12M",
+                                    "Stop": [
+                                        {
+                                            "dep": "2019-12-24T12:14:00",
+                                            "arr": "2019-12-24T12:08:00",
+                                            "Stn": {
+                                                "id": "db_8000105#81",
+                                                "name": "Frankfurt(Main)Hbf",
+                                                "x": 8.663785,
+                                                "y": 50.107149
+                                            }
+                                        },
+                                        {
+                                            "dep": "2019-12-24T13:09:00",
+                                            "arr": "2019-12-24T13:07:00",
+                                            "Stn": {
+                                                "id": "db_8000115#81",
+                                                "name": "Fulda",
+                                                "x": 9.68398,
+                                                "y": 50.554722
+                                            }
+                                        },
+                                        {
+                                            "dep": "2019-12-24T14:02:00",
+                                            "arr": "2019-12-24T14:00:00",
+                                            "Stn": {
+                                                "id": "db_8010097#81",
+                                                "name": "Eisenach",
+                                                "x": 10.331986,
+                                                "y": 50.976919
+                                            }
+                                        },
+                                        {
+                                            "dep": "2019-12-24T14:28:00",
+                                            "arr": "2019-12-24T14:26:00",
+                                            "Stn": {
+                                                "id": "db_8010101#81",
+                                                "name": "Erfurt Hbf",
+                                                "x": 11.038502,
+                                                "y": 50.97255
+                                            }
+                                        }
+                                    ]
+                                },
+                                "Arr": {
+                                    "time": "2019-12-24T14:26:00",
+                                    "platform": "10",
+                                    "Stn": {
+                                        "id": "db_8010101#81",
+                                        "name": "Erfurt Hbf",
+                                        "x": 11.038502,
+                                        "y": 50.97255
+                                    }
+                                }
+                            },
+                            {
+                                "mode": 0,
+                                "id": "R001634-C4-S5",
+                                "Dep": {
+                                    "time": "2019-12-24T14:32:00",
+                                    "platform": "9",
+                                    "Stn": {
+                                        "id": "db_8010101#81",
+                                        "name": "Erfurt Hbf",
+                                        "x": 11.038502,
+                                        "y": 50.97255
+                                    },
+                                    "Transport": {
+                                        "mode": 0,
+                                        "dir": "Hamburg-Altona",
+                                        "name": "ICE 708",
+                                        "At": {
+                                            "category": "Intercity-Express",
+                                            "operator": "DB",
+                                            "color": "#EC1B2D"
+                                        }
+                                    },
+                                    "Freq": {
+                                        "min": 19,
+                                        "max": 56,
+                                        "AltDep": [
+                                            {
+                                                "time": "2019-12-24T15:09:00",
+                                                "Transport": {
+                                                    "mode": 0,
+                                                    "dir": "Berlin Hbf (tief)",
+                                                    "name": "ICE 939",
+                                                    "At": {
+                                                        "category": "Intercity-Express",
+                                                        "operator": "DB",
+                                                        "color": "#EC1B2D"
+                                                    }
+                                                }
+                                            },
+                                            {
+                                                "time": "2019-12-24T15:28:00",
+                                                "Transport": {
+                                                    "mode": 0,
+                                                    "dir": "Hamburg-Altona",
+                                                    "name": "ICE 506",
+                                                    "At": {
+                                                        "category": "Intercity-Express",
+                                                        "operator": "DB",
+                                                        "color": "#EC1B2D"
+                                                    }
+                                                }
+                                            },
+                                            {
+                                                "time": "2019-12-24T16:04:00",
+                                                "Transport": {
+                                                    "mode": 0,
+                                                    "dir": "Berlin Gesundbrunnen",
+                                                    "name": "ICE 1092",
+                                                    "At": {
+                                                        "category": "Intercity-Express",
+                                                        "operator": "DB",
+                                                        "color": "#EC1B2D"
+                                                    }
+                                                }
+                                            }
+                                        ]
+                                    }
+                                },
+                                "Journey": {
+                                    "duration": "PT1H52M",
+                                    "Stop": [
+                                        {
+                                            "dep": "2019-12-24T14:32:00",
+                                            "arr": "2019-12-24T14:24:00",
+                                            "Stn": {
+                                                "id": "db_8010101#81",
+                                                "name": "Erfurt Hbf",
+                                                "x": 11.038502,
+                                                "y": 50.97255
+                                            }
+                                        },
+                                        {
+                                            "dep": "2019-12-24T15:06:00",
+                                            "arr": "2019-12-24T15:04:00",
+                                            "Stn": {
+                                                "id": "db_8010159#81",
+                                                "name": "Halle(Saale)Hbf",
+                                                "x": 11.987088,
+                                                "y": 51.47751
+                                            }
+                                        },
+                                        {
+                                            "dep": "2019-12-24T15:24:00",
+                                            "arr": "2019-12-24T15:22:00",
+                                            "Stn": {
+                                                "id": "db_8010050#81",
+                                                "name": "Bitterfeld",
+                                                "x": 12.316849,
+                                                "y": 51.622857
+                                            }
+                                        },
+                                        {
+                                            "dep": "2019-12-24T16:19:00",
+                                            "arr": "2019-12-24T16:17:00",
+                                            "Stn": {
+                                                "id": "db_8011113#81",
+                                                "name": "Berlin Südkreuz",
+                                                "x": 13.365315,
+                                                "y": 52.475043
+                                            }
+                                        },
+                                        {
+                                            "dep": "2019-12-24T16:38:00",
+                                            "arr": "2019-12-24T16:24:00",
+                                            "Stn": {
+                                                "id": "db_8098160#81",
+                                                "name": "Berlin Hbf (tief)",
+                                                "x": 13.369549,
+                                                "y": 52.525589
+                                            }
+                                        }
+                                    ]
+                                },
+                                "Arr": {
+                                    "time": "2019-12-24T16:24:00",
+                                    "platform": "7",
+                                    "Stn": {
+                                        "id": "db_8098160#81",
+                                        "name": "Berlin Hbf (tief)",
+                                        "x": 13.369549,
+                                        "y": 52.525589
+                                    }
+                                }
+                            },
+                            {
+                                "mode": 20,
+                                "id": "R001634-C4-S6",
+                                "Dep": {
+                                    "time": "2019-12-24T16:24:00",
+                                    "Stn": {
+                                        "id": "db_8098160#81",
+                                        "name": "Berlin Hbf (tief)",
+                                        "x": 13.369549,
+                                        "y": 52.525589
+                                    },
+                                    "Transport": {
+                                        "mode": 20
+                                    }
+                                },
+                                "Journey": {
+                                    "duration": "PT9M",
+                                    "distance": 500
+                                },
+                                "Arr": {
+                                    "time": "2019-12-24T16:33:00",
+                                    "Stn": {
+                                        "id": "db_8089021#81",
+                                        "name": "Berlin Hbf (S-Bahn)",
+                                        "x": 13.369549,
+                                        "y": 52.525589
+                                    }
+                                }
+                            },
+                            {
+                                "mode": 4,
+                                "id": "R001634-C4-S7",
+                                "Dep": {
+                                    "time": "2019-12-24T16:35:00",
+                                    "platform": "15",
+                                    "Stn": {
+                                        "id": "db_8089021#81",
+                                        "name": "Berlin Hbf (S-Bahn)",
+                                        "x": 13.369549,
+                                        "y": 52.525589
+                                    },
+                                    "Transport": {
+                                        "mode": 4,
+                                        "dir": "Erkner (S)",
+                                        "name": "S3",
+                                        "At": {
+                                            "category": "S-Bahn",
+                                            "operator": "DB",
+                                            "color": "#0068B1"
+                                        }
+                                    },
+                                    "Freq": {
+                                        "min": 3,
+                                        "max": 10,
+                                        "AltDep": [
+                                            {
+                                                "time": "2019-12-24T16:38:00",
+                                                "Transport": {
+                                                    "mode": 4,
+                                                    "dir": "Ahrensfelde (S)",
+                                                    "name": "S7",
+                                                    "At": {
+                                                        "category": "S-Bahn",
+                                                        "operator": "DB",
+                                                        "color": "#7D6AAA"
+                                                    }
+                                                }
+                                            },
+                                            {
+                                                "time": "2019-12-24T16:41:00",
+                                                "Transport": {
+                                                    "mode": 4,
+                                                    "dir": "Strausberg Nord",
+                                                    "name": "S5",
+                                                    "At": {
+                                                        "category": "S-Bahn",
+                                                        "operator": "DB",
+                                                        "color": "#F27B26"
+                                                    }
+                                                }
+                                            },
+                                            {
+                                                "time": "2019-12-24T16:45:00",
+                                                "Transport": {
+                                                    "mode": 4,
+                                                    "dir": "Berlin-Schönefeld Flughafen",
+                                                    "name": "S9",
+                                                    "At": {
+                                                        "category": "S-Bahn",
+                                                        "operator": "DB",
+                                                        "color": "#953450"
+                                                    }
+                                                }
+                                            }
+                                        ]
+                                    }
+                                },
+                                "Journey": {
+                                    "duration": "PT4M",
+                                    "Stop": [
+                                        {
+                                            "dep": "2019-12-24T16:35:00",
+                                            "Stn": {
+                                                "id": "db_8089021#81",
+                                                "name": "Berlin Hbf (S-Bahn)",
+                                                "x": 13.369549,
+                                                "y": 52.525589
+                                            }
+                                        },
+                                        {
+                                            "dep": "2019-12-24T16:38:00",
+                                            "arr": "2019-12-24T16:37:00",
+                                            "Stn": {
+                                                "id": "db_8089066#81",
+                                                "name": "Berlin Friedrichstraße (S)",
+                                                "x": 13.386907,
+                                                "y": 52.520178
+                                            }
+                                        },
+                                        {
+                                            "dep": "2019-12-24T16:40:00",
+                                            "arr": "2019-12-24T16:39:00",
+                                            "Stn": {
+                                                "id": "db_8089017#81",
+                                                "name": "Berlin Hackescher Markt",
+                                                "x": 13.402368,
+                                                "y": 52.522623
+                                            }
+                                        }
+                                    ]
+                                },
+                                "Arr": {
+                                    "time": "2019-12-24T16:39:00",
+                                    "platform": "3",
+                                    "Stn": {
+                                        "id": "db_8089017#81",
+                                        "name": "Berlin Hackescher Markt",
+                                        "x": 13.402368,
+                                        "y": 52.522623
+                                    }
+                                }
+                            },
+                            {
+                                "mode": 20,
+                                "id": "R001634-C4-S8",
+                                "Dep": {
+                                    "time": "2019-12-24T16:39:00",
+                                    "Stn": {
+                                        "id": "db_8089017#81",
+                                        "name": "Berlin Hackescher Markt",
+                                        "x": 13.402368,
+                                        "y": 52.522623
+                                    },
+                                    "Transport": {
+                                        "mode": 20
+                                    }
+                                },
+                                "Journey": {
+                                    "duration": "PT3M",
+                                    "distance": 149
+                                },
+                                "Arr": {
+                                    "time": "2019-12-24T16:42:00",
+                                    "Addr": {
+                                        "x": 13.403411,
+                                        "y": 52.521436
+                                    }
+                                }
+                            }
+                        ]
+                    }
+                },
+                {
+                    "id": "R001634-C5",
+                    "duration": "PT5H20M",
+                    "transfers": 3,
+                    "Dep": {
+                        "time": "2019-12-24T11:25:00",
+                        "Addr": {
+                            "x": 8.276386,
+                            "y": 49.999252
+                        }
+                    },
+                    "Arr": {
+                        "time": "2019-12-24T16:45:00",
+                        "Addr": {
+                            "x": 13.403411,
+                            "y": 52.521436
+                        }
+                    },
+                    "Sections": {
+                        "Sec": [
+                            {
+                                "mode": 20,
+                                "id": "R001634-C5-S0",
+                                "Dep": {
+                                    "time": "2019-12-24T11:25:00",
+                                    "Addr": {
+                                        "x": 8.276386,
+                                        "y": 49.999252
+                                    },
+                                    "Transport": {
+                                        "mode": 20
+                                    }
+                                },
+                                "Journey": {
+                                    "duration": "PT5M",
+                                    "distance": 248
+                                },
+                                "Arr": {
+                                    "time": "2019-12-24T11:30:00",
+                                    "Stn": {
+                                        "id": "db_405371#81",
+                                        "name": "Rheingoldhalle/Rathaus",
+                                        "x": 8.275559,
+                                        "y": 50.001418
+                                    }
+                                }
+                            },
+                            {
+                                "mode": 5,
+                                "id": "R001634-C5-S1",
+                                "Dep": {
+                                    "time": "2019-12-24T11:30:00",
+                                    "Stn": {
+                                        "id": "db_405371#81",
+                                        "name": "Rheingoldhalle/Rathaus",
+                                        "x": 8.275559,
+                                        "y": 50.001418
+                                    },
+                                    "Transport": {
+                                        "mode": 5,
+                                        "dir": "Altenwohnheim",
+                                        "name": "68",
+                                        "At": {
+                                            "category": "Bus",
+                                            "operator": "DB"
+                                        }
+                                    },
+                                    "Freq": {
+                                        "min": 3,
+                                        "max": 12,
+                                        "AltDep": [
+                                            {
+                                                "time": "2019-12-24T11:34:00",
+                                                "Transport": {
+                                                    "mode": 5,
+                                                    "dir": "Treburer Straße",
+                                                    "name": "58",
+                                                    "At": {
+                                                        "category": "Bus",
+                                                        "operator": "DB"
+                                                    }
+                                                }
+                                            },
+                                            {
+                                                "time": "2019-12-24T11:46:00",
+                                                "Transport": {
+                                                    "mode": 5,
+                                                    "dir": "Mainz-Kastel Krautgärten",
+                                                    "name": "57",
+                                                    "At": {
+                                                        "category": "Bus",
+                                                        "operator": "DB"
+                                                    }
+                                                }
+                                            },
+                                            {
+                                                "time": "2019-12-24T11:49:00",
+                                                "Transport": {
+                                                    "mode": 5,
+                                                    "dir": "Ginsheim Friedr.-Ebert-Platz",
+                                                    "name": "56",
+                                                    "At": {
+                                                        "category": "Bus",
+                                                        "operator": "DB"
+                                                    }
+                                                }
+                                            }
+                                        ]
+                                    }
+                                },
+                                "Journey": {
+                                    "duration": "PT4M",
+                                    "Stop": [
+                                        {
+                                            "dep": "2019-12-24T11:30:00",
+                                            "Stn": {
+                                                "id": "db_405371#81",
+                                                "name": "Rheingoldhalle/Rathaus",
+                                                "x": 8.275559,
+                                                "y": 50.001418
+                                            }
+                                        },
+                                        {
+                                            "dep": "2019-12-24T11:31:00",
+                                            "Stn": {
+                                                "id": "db_405181#81",
+                                                "name": "Brückenplatz",
+                                                "x": 8.274256,
+                                                "y": 50.00309
+                                            }
+                                        },
+                                        {
+                                            "dep": "2019-12-24T11:33:00",
+                                            "Stn": {
+                                                "id": "db_408022#81",
+                                                "name": "Mainz-Kastel Brückenkopf",
+                                                "x": 8.280189,
+                                                "y": 50.008061
+                                            }
+                                        },
+                                        {
+                                            "dep": "2019-12-24T11:34:00",
+                                            "Stn": {
+                                                "id": "db_405184#81",
+                                                "name": "Mainz-Kastel Bahnhof",
+                                                "x": 8.283784,
+                                                "y": 50.006929
+                                            }
+                                        }
+                                    ]
+                                },
+                                "Arr": {
+                                    "time": "2019-12-24T11:34:00",
+                                    "Stn": {
+                                        "id": "db_405184#81",
+                                        "name": "Mainz-Kastel Bahnhof",
+                                        "x": 8.283784,
+                                        "y": 50.006929
+                                    }
+                                }
+                            },
+                            {
+                                "mode": 20,
+                                "id": "R001634-C5-S2",
+                                "Dep": {
+                                    "time": "2019-12-24T11:34:00",
+                                    "Stn": {
+                                        "id": "db_405184#81",
+                                        "name": "Mainz-Kastel Bahnhof",
+                                        "x": 8.283784,
+                                        "y": 50.006929
+                                    },
+                                    "Transport": {
+                                        "mode": 20
+                                    }
+                                },
+                                "Journey": {
+                                    "duration": "PT3M",
+                                    "distance": 559
+                                },
+                                "Arr": {
+                                    "time": "2019-12-24T11:37:00",
+                                    "Stn": {
+                                        "id": "db_8000615#81",
+                                        "name": "Mainz-Kastel",
+                                        "x": 8.283173,
+                                        "y": 50.006578
+                                    }
+                                }
+                            },
+                            {
+                                "mode": 3,
+                                "id": "R001634-C5-S3",
+                                "Dep": {
+                                    "time": "2019-12-24T11:39:00",
+                                    "platform": "2",
+                                    "Stn": {
+                                        "id": "db_8000615#81",
+                                        "name": "Mainz-Kastel",
+                                        "x": 8.283173,
+                                        "y": 50.006578
+                                    },
+                                    "Transport": {
+                                        "mode": 3,
+                                        "dir": "Frankfurt(Main)Hbf",
+                                        "name": "VIA25013",
+                                        "At": {
+                                            "category": "VIAS GmbH",
+                                            "operator": "DB",
+                                            "color": "#EC1B2D"
+                                        }
+                                    },
+                                    "Freq": {
+                                        "min": 60,
+                                        "max": 60,
+                                        "AltDep": [
+                                            {
+                                                "time": "2019-12-24T12:39:00",
+                                                "Transport": {
+                                                    "mode": 3,
+                                                    "dir": "Frankfurt(Main)Hbf",
+                                                    "name": "VIA25015",
+                                                    "At": {
+                                                        "category": "VIAS GmbH",
+                                                        "operator": "DB",
+                                                        "color": "#EC1B2D"
+                                                    }
+                                                }
+                                            },
+                                            {
+                                                "time": "2019-12-24T13:39:00",
+                                                "Transport": {
+                                                    "mode": 3,
+                                                    "dir": "Frankfurt(Main)Hbf",
+                                                    "name": "VIA25017",
+                                                    "At": {
+                                                        "category": "VIAS GmbH",
+                                                        "operator": "DB",
+                                                        "color": "#EC1B2D"
+                                                    }
+                                                }
+                                            },
+                                            {
+                                                "time": "2019-12-24T14:39:00",
+                                                "Transport": {
+                                                    "mode": 3,
+                                                    "dir": "Frankfurt(Main)Hbf",
+                                                    "name": "VIA25019",
+                                                    "At": {
+                                                        "category": "VIAS GmbH",
+                                                        "operator": "DB",
+                                                        "color": "#EC1B2D"
+                                                    }
+                                                }
+                                            }
+                                        ]
+                                    }
+                                },
+                                "Journey": {
+                                    "duration": "PT26M",
+                                    "Stop": [
+                                        {
+                                            "dep": "2019-12-24T11:39:00",
+                                            "arr": "2019-12-24T11:38:00",
+                                            "Stn": {
+                                                "id": "db_8000615#81",
+                                                "name": "Mainz-Kastel",
+                                                "x": 8.283173,
+                                                "y": 50.006578
+                                            }
+                                        },
+                                        {
+                                            "dep": "2019-12-24T11:55:00",
+                                            "arr": "2019-12-24T11:54:00",
+                                            "Stn": {
+                                                "id": "db_8000106#81",
+                                                "name": "Frankfurt-Höchst",
+                                                "x": 8.542368,
+                                                "y": 50.102637
+                                            }
+                                        },
+                                        {
+                                            "arr": "2019-12-24T12:05:00",
+                                            "Stn": {
+                                                "id": "db_8000105#81",
+                                                "name": "Frankfurt(Main)Hbf",
+                                                "x": 8.663785,
+                                                "y": 50.107149
+                                            }
+                                        }
+                                    ]
+                                },
+                                "Arr": {
+                                    "time": "2019-12-24T12:05:00",
+                                    "platform": "23",
+                                    "Stn": {
+                                        "id": "db_8000105#81",
+                                        "name": "Frankfurt(Main)Hbf",
+                                        "x": 8.663785,
+                                        "y": 50.107149
+                                    }
+                                }
+                            },
+                            {
+                                "mode": 0,
+                                "id": "R001634-C5-S4",
+                                "Dep": {
+                                    "time": "2019-12-24T12:14:00",
+                                    "platform": "8",
+                                    "Stn": {
+                                        "id": "db_8000105#81",
+                                        "name": "Frankfurt(Main)Hbf",
+                                        "x": 8.663785,
+                                        "y": 50.107149
+                                    },
+                                    "Transport": {
+                                        "mode": 0,
+                                        "dir": "Berlin Gesundbrunnen",
+                                        "name": "ICE 690",
+                                        "At": {
+                                            "category": "Intercity-Express",
+                                            "operator": "DB",
+                                            "color": "#EC1B2D"
+                                        }
+                                    },
+                                    "Freq": {
+                                        "min": 12,
+                                        "max": 60,
+                                        "AltDep": [
+                                            {
+                                                "time": "2019-12-24T13:02:00",
+                                                "Transport": {
+                                                    "mode": 0,
+                                                    "dir": "Berlin Hbf (tief)",
+                                                    "name": "ICE 939",
+                                                    "At": {
+                                                        "category": "Intercity-Express",
+                                                        "operator": "DB",
+                                                        "color": "#EC1B2D"
+                                                    }
+                                                }
+                                            },
+                                            {
+                                                "time": "2019-12-24T13:14:00",
+                                                "Transport": {
+                                                    "mode": 0,
+                                                    "dir": "Berlin Ostbahnhof",
+                                                    "name": "ICE 370",
+                                                    "At": {
+                                                        "category": "Intercity-Express",
+                                                        "operator": "DB",
+                                                        "color": "#EC1B2D"
+                                                    }
+                                                }
+                                            },
+                                            {
+                                                "time": "2019-12-24T14:14:00",
+                                                "Transport": {
+                                                    "mode": 0,
+                                                    "dir": "Berlin Gesundbrunnen",
+                                                    "name": "ICE 598",
+                                                    "At": {
+                                                        "category": "Intercity-Express",
+                                                        "operator": "DB",
+                                                        "color": "#EC1B2D"
+                                                    }
+                                                }
+                                            }
+                                        ]
+                                    }
+                                },
+                                "Journey": {
+                                    "duration": "PT4H15M",
+                                    "Stop": [
+                                        {
+                                            "dep": "2019-12-24T12:14:00",
+                                            "arr": "2019-12-24T12:08:00",
+                                            "Stn": {
+                                                "id": "db_8000105#81",
+                                                "name": "Frankfurt(Main)Hbf",
+                                                "x": 8.663785,
+                                                "y": 50.107149
+                                            }
+                                        },
+                                        {
+                                            "dep": "2019-12-24T13:09:00",
+                                            "arr": "2019-12-24T13:07:00",
+                                            "Stn": {
+                                                "id": "db_8000115#81",
+                                                "name": "Fulda",
+                                                "x": 9.68398,
+                                                "y": 50.554722
+                                            }
+                                        },
+                                        {
+                                            "dep": "2019-12-24T14:02:00",
+                                            "arr": "2019-12-24T14:00:00",
+                                            "Stn": {
+                                                "id": "db_8010097#81",
+                                                "name": "Eisenach",
+                                                "x": 10.331986,
+                                                "y": 50.976919
+                                            }
+                                        },
+                                        {
+                                            "dep": "2019-12-24T14:28:00",
+                                            "arr": "2019-12-24T14:26:00",
+                                            "Stn": {
+                                                "id": "db_8010101#81",
+                                                "name": "Erfurt Hbf",
+                                                "x": 11.038502,
+                                                "y": 50.97255
+                                            }
+                                        },
+                                        {
+                                            "dep": "2019-12-24T15:16:00",
+                                            "arr": "2019-12-24T15:10:00",
+                                            "Stn": {
+                                                "id": "db_8010205#81",
+                                                "name": "Leipzig Hbf",
+                                                "x": 12.382066,
+                                                "y": 51.345467
+                                            }
+                                        },
+                                        {
+                                            "dep": "2019-12-24T15:48:00",
+                                            "arr": "2019-12-24T15:46:00",
+                                            "Stn": {
+                                                "id": "db_8010222#81",
+                                                "name": "Lutherstadt Wittenberg Hbf",
+                                                "x": 12.662286,
+                                                "y": 51.867813
+                                            }
+                                        },
+                                        {
+                                            "arr": "2019-12-24T16:22:00",
+                                            "Stn": {
+                                                "id": "db_8011113#81",
+                                                "name": "Berlin Südkreuz",
+                                                "x": 13.365315,
+                                                "y": 52.475043
+                                            }
+                                        },
+                                        {
+                                            "arr": "2019-12-24T16:29:00",
+                                            "Stn": {
+                                                "id": "db_8098160#81",
+                                                "name": "Berlin Hbf (tief)",
+                                                "x": 13.369549,
+                                                "y": 52.525589
+                                            }
+                                        }
+                                    ]
+                                },
+                                "Arr": {
+                                    "time": "2019-12-24T16:29:00",
+                                    "platform": "6",
+                                    "Stn": {
+                                        "id": "db_8098160#81",
+                                        "name": "Berlin Hbf (tief)",
+                                        "x": 13.369549,
+                                        "y": 52.525589
+                                    }
+                                }
+                            },
+                            {
+                                "mode": 20,
+                                "id": "R001634-C5-S5",
+                                "Dep": {
+                                    "time": "2019-12-24T16:29:00",
+                                    "Stn": {
+                                        "id": "db_8098160#81",
+                                        "name": "Berlin Hbf (tief)",
+                                        "x": 13.369549,
+                                        "y": 52.525589
+                                    },
+                                    "Transport": {
+                                        "mode": 20
+                                    }
+                                },
+                                "Journey": {
+                                    "duration": "PT9M",
+                                    "distance": 500
+                                },
+                                "Arr": {
+                                    "time": "2019-12-24T16:38:00",
+                                    "Stn": {
+                                        "id": "db_8089021#81",
+                                        "name": "Berlin Hbf (S-Bahn)",
+                                        "x": 13.369549,
+                                        "y": 52.525589
+                                    }
+                                }
+                            },
+                            {
+                                "mode": 4,
+                                "id": "R001634-C5-S6",
+                                "Dep": {
+                                    "time": "2019-12-24T16:38:00",
+                                    "platform": "15",
+                                    "Stn": {
+                                        "id": "db_8089021#81",
+                                        "name": "Berlin Hbf (S-Bahn)",
+                                        "x": 13.369549,
+                                        "y": 52.525589
+                                    },
+                                    "Transport": {
+                                        "mode": 4,
+                                        "dir": "Ahrensfelde (S)",
+                                        "name": "S7",
+                                        "At": {
+                                            "category": "S-Bahn",
+                                            "operator": "DB",
+                                            "color": "#7D6AAA"
+                                        }
+                                    },
+                                    "Freq": {
+                                        "min": 3,
+                                        "max": 10,
+                                        "AltDep": [
+                                            {
+                                                "time": "2019-12-24T16:41:00",
+                                                "Transport": {
+                                                    "mode": 4,
+                                                    "dir": "Strausberg Nord",
+                                                    "name": "S5",
+                                                    "At": {
+                                                        "category": "S-Bahn",
+                                                        "operator": "DB",
+                                                        "color": "#F27B26"
+                                                    }
+                                                }
+                                            },
+                                            {
+                                                "time": "2019-12-24T16:45:00",
+                                                "Transport": {
+                                                    "mode": 4,
+                                                    "dir": "Berlin-Schönefeld Flughafen",
+                                                    "name": "S9",
+                                                    "At": {
+                                                        "category": "S-Bahn",
+                                                        "operator": "DB",
+                                                        "color": "#953450"
+                                                    }
+                                                }
+                                            },
+                                            {
+                                                "time": "2019-12-24T16:48:00",
+                                                "Transport": {
+                                                    "mode": 4,
+                                                    "dir": "Berlin Ostbahnhof (S)",
+                                                    "name": "S7",
+                                                    "At": {
+                                                        "category": "S-Bahn",
+                                                        "operator": "DB",
+                                                        "color": "#7D6AAA"
+                                                    }
+                                                }
+                                            }
+                                        ]
+                                    }
+                                },
+                                "Journey": {
+                                    "duration": "PT4M",
+                                    "Stop": [
+                                        {
+                                            "dep": "2019-12-24T16:38:00",
+                                            "Stn": {
+                                                "id": "db_8089021#81",
+                                                "name": "Berlin Hbf (S-Bahn)",
+                                                "x": 13.369549,
+                                                "y": 52.525589
+                                            }
+                                        },
+                                        {
+                                            "dep": "2019-12-24T16:41:00",
+                                            "arr": "2019-12-24T16:40:00",
+                                            "Stn": {
+                                                "id": "db_8089066#81",
+                                                "name": "Berlin Friedrichstraße (S)",
+                                                "x": 13.386907,
+                                                "y": 52.520178
+                                            }
+                                        },
+                                        {
+                                            "dep": "2019-12-24T16:43:00",
+                                            "arr": "2019-12-24T16:42:00",
+                                            "Stn": {
+                                                "id": "db_8089017#81",
+                                                "name": "Berlin Hackescher Markt",
+                                                "x": 13.402368,
+                                                "y": 52.522623
+                                            }
+                                        }
+                                    ]
+                                },
+                                "Arr": {
+                                    "time": "2019-12-24T16:42:00",
+                                    "platform": "3",
+                                    "Stn": {
+                                        "id": "db_8089017#81",
+                                        "name": "Berlin Hackescher Markt",
+                                        "x": 13.402368,
+                                        "y": 52.522623
+                                    }
+                                }
+                            },
+                            {
+                                "mode": 20,
+                                "id": "R001634-C5-S7",
+                                "Dep": {
+                                    "time": "2019-12-24T16:42:00",
+                                    "Stn": {
+                                        "id": "db_8089017#81",
+                                        "name": "Berlin Hackescher Markt",
+                                        "x": 13.402368,
+                                        "y": 52.522623
+                                    },
+                                    "Transport": {
+                                        "mode": 20
+                                    }
+                                },
+                                "Journey": {
+                                    "duration": "PT3M",
+                                    "distance": 149
+                                },
+                                "Arr": {
+                                    "time": "2019-12-24T16:45:00",
+                                    "Addr": {
+                                        "x": 13.403411,
+                                        "y": 52.521436
+                                    }
+                                }
+                            }
+                        ]
+                    }
+                },
+                {
+                    "id": "R001634-C6",
+                    "duration": "PT8H40M0S",
+                    "transfers": 2,
+                    "Dep": {
+                        "time": "2019-12-24T11:44:00",
+                        "Addr": {
+                            "y": 49.999249,
+                            "x": 8.276387
+                        }
+                    },
+                    "Arr": {
+                        "time": "2019-12-24T20:24:00",
+                        "Addr": {
+                            "x": 13.403411,
+                            "y": 52.521436
+                        }
+                    },
+                    "Sections": {
+                        "Sec": [
+                            {
+                                "id": "R001634-C6-S0",
+                                "mode": 20,
+                                "Dep": {
+                                    "time": "2019-12-24T11:44:00",
+                                    "Addr": {
+                                        "y": 49.999249,
+                                        "x": 8.276387
+                                    },
+                                    "Transport": {
+                                        "mode": 20
+                                    }
+                                },
+                                "Journey": {
+                                    "distance": 1760,
+                                    "duration": "PT06M"
+                                },
+                                "Arr": {
+                                    "time": "2019-12-24T11:50:00",
+                                    "Stn": {
+                                        "y": 50.003314,
+                                        "x": 8.257726,
+                                        "name": "Mainz",
+                                        "id": "723881538"
+                                    }
+                                }
+                            },
+                            {
+                                "id": "R001634-C6-S1",
+                                "mode": 12,
+                                "Dep": {
+                                    "time": "2019-12-24T11:50:00",
+                                    "Stn": {
+                                        "y": 50.003314,
+                                        "x": 8.257726,
+                                        "name": "Mainz",
+                                        "id": "723881538"
+                                    },
+                                    "Transport": {
+                                        "mode": 12,
+                                        "dir": "Berlin central bus station",
+                                        "name": "FlixBus",
+                                        "At": {
+                                            "category": "Bus",
+                                            "color": "#73D700",
+                                            "textColor": "#FFFFFF",
+                                            "operator": "h2UFLI00"
+                                        }
+                                    },
+                                    "Freq": {
+                                        "min": 0,
+                                        "max": 0,
+                                        "AltDep": [
+                                            {
+                                                "time": "2019-12-24T11:50:00",
+                                                "Transport": {
+                                                    "mode": 12,
+                                                    "dir": "Berlin central bus station",
+                                                    "name": "FlixBus",
+                                                    "At": {
+                                                        "category": "Bus",
+                                                        "color": "#73D700",
+                                                        "textColor": "#FFFFFF",
+                                                        "operator": "h2UFLI00"
+                                                    }
+                                                }
+                                            }
+                                        ]
+                                    }
+                                },
+                                "Journey": {
+                                    "distance": 582259,
+                                    "duration": "PT07H50M",
+                                    "Stop": [
+                                        {
+                                            "dep": "2019-12-24T11:50:00",
+                                            "Stn": {
+                                                "y": 50.003314,
+                                                "x": 8.257726,
+                                                "name": "Mainz",
+                                                "id": "723881538"
+                                            }
+                                        },
+                                        {
+                                            "arr": "2019-12-24T12:25:00",
+                                            "dep": "2019-12-24T12:30:00",
+                                            "Stn": {
+                                                "y": 50.052682,
+                                                "x": 8.57749,
+                                                "name": "Frankfurt Airport",
+                                                "id": "723882424"
+                                            }
+                                        },
+                                        {
+                                            "arr": "2019-12-24T12:50:00",
+                                            "dep": "2019-12-24T13:05:00",
+                                            "Stn": {
+                                                "y": 50.104394,
+                                                "x": 8.662577,
+                                                "name": "Frankfurt, Frankfurt central station",
+                                                "id": "723881779"
+                                            }
+                                        },
+                                        {
+                                            "arr": "2019-12-24T14:50:00",
+                                            "dep": "2019-12-24T14:55:00",
+                                            "Stn": {
+                                                "y": 50.868874,
+                                                "x": 9.715226,
+                                                "name": "Bad Hersfeld, Bad Hersfeld, station",
+                                                "id": "723882158"
+                                            }
+                                        },
+                                        {
+                                            "arr": "2019-12-24T19:40:00",
+                                            "Stn": {
+                                                "y": 52.507171,
+                                                "x": 13.279399,
+                                                "name": "Berlin, Berlin central bus station",
+                                                "id": "723880688"
+                                            }
+                                        }
+                                    ]
+                                },
+                                "Arr": {
+                                    "time": "2019-12-24T19:40:00",
+                                    "Stn": {
+                                        "y": 52.507171,
+                                        "x": 13.279399,
+                                        "name": "Berlin, Berlin central bus station",
+                                        "id": "723880688"
+                                    }
+                                }
+                            },
+                            {
+                                "id": "R001634-C6-S2",
+                                "mode": 20,
+                                "Dep": {
+                                    "time": "2019-12-24T19:40:00",
+                                    "Stn": {
+                                        "x": 13.279399,
+                                        "y": 52.507171,
+                                        "id": "723880688",
+                                        "name": "Berlin, Berlin central bus station"
+                                    },
+                                    "Transport": {
+                                        "mode": 20
+                                    }
+                                },
+                                "Journey": {
+                                    "duration": "PT6M",
+                                    "distance": 316
+                                },
+                                "Arr": {
+                                    "time": "2019-12-24T19:46:00",
+                                    "Stn": {
+                                        "id": "vbb_900024106",
+                                        "name": "S Messe Nord/ICC",
+                                        "x": 13.283045,
+                                        "y": 52.506451
+                                    }
+                                }
+                            },
+                            {
+                                "id": "R001634-C6-S3",
+                                "mode": 4,
+                                "Dep": {
+                                    "time": "2019-12-24T19:55:00",
+                                    "platform": "2",
+                                    "Stn": {
+                                        "id": "vbb_900024106",
+                                        "name": "S Messe Nord/ICC",
+                                        "x": 13.283045,
+                                        "y": 52.506451
+                                    },
+                                    "Transport": {
+                                        "mode": 4,
+                                        "name": "S42",
+                                        "dir": "Ringbahn S 42",
+                                        "At": {
+                                            "category": "S-Bahn",
+                                            "operator": "DBS",
+                                            "textColor": "#FFFFFF",
+                                            "color": "#BF5A2A",
+                                            "iconId": "BERLIN_BRANDENBURG_EXT/s-bahn",
+                                            "iconShape": "RoundedRect"
+                                        }
+                                    }
+                                },
+                                "Journey": {
+                                    "duration": "PT2M",
+                                    "Stop": [
+                                        {
+                                            "dep": "2019-12-24T19:55:00",
+                                            "Stn": {
+                                                "id": "vbb_900024106",
+                                                "name": "S Messe Nord/ICC",
+                                                "x": 13.283045,
+                                                "y": 52.506451
+                                            }
+                                        },
+                                        {
+                                            "arr": "2019-12-24T19:57:00",
+                                            "Stn": {
+                                                "id": "vbb_900024102",
+                                                "name": "S Westkreuz",
+                                                "x": 13.283036,
+                                                "y": 52.501148
+                                            }
+                                        }
+                                    ]
+                                },
+                                "Arr": {
+                                    "time": "2019-12-24T19:57:00",
+                                    "platform": "12",
+                                    "Stn": {
+                                        "id": "vbb_900024102",
+                                        "name": "S Westkreuz",
+                                        "x": 13.283036,
+                                        "y": 52.501148
+                                    }
+                                }
+                            },
+                            {
+                                "id": "R001634-C6-S4",
+                                "mode": 4,
+                                "Dep": {
+                                    "time": "2019-12-24T20:02:00",
+                                    "platform": "4",
+                                    "Stn": {
+                                        "id": "vbb_900024102",
+                                        "name": "S Westkreuz",
+                                        "x": 13.283036,
+                                        "y": 52.501148
+                                    },
+                                    "Transport": {
+                                        "mode": 4,
+                                        "name": "S3",
+                                        "dir": "S Erkner Bhf",
+                                        "At": {
+                                            "category": "S-Bahn",
+                                            "operator": "DBS",
+                                            "textColor": "#FFFFFF",
+                                            "color": "#166AB8",
+                                            "iconId": "BERLIN_BRANDENBURG_EXT/s-bahn",
+                                            "iconShape": "RoundedRect"
+                                        }
+                                    }
+                                },
+                                "Journey": {
+                                    "duration": "PT17M",
+                                    "Stop": [
+                                        {
+                                            "dep": "2019-12-24T20:02:00",
+                                            "Stn": {
+                                                "id": "vbb_900024102",
+                                                "name": "S Westkreuz",
+                                                "x": 13.283036,
+                                                "y": 52.501148
+                                            }
+                                        },
+                                        {
+                                            "dep": "2019-12-24T20:04:00",
+                                            "Stn": {
+                                                "id": "vbb_900024101",
+                                                "name": "S Charlottenburg Bhf",
+                                                "x": 13.303846,
+                                                "y": 52.504806
+                                            }
+                                        },
+                                        {
+                                            "dep": "2019-12-24T20:06:00",
+                                            "Stn": {
+                                                "id": "vbb_900024203",
+                                                "name": "S Savignyplatz",
+                                                "x": 13.319002,
+                                                "y": 52.50522
+                                            }
+                                        },
+                                        {
+                                            "dep": "2019-12-24T20:08:00",
+                                            "Stn": {
+                                                "id": "vbb_900023201",
+                                                "name": "S+U Zoologischer Garten Bhf",
+                                                "x": 13.332711,
+                                                "y": 52.506919
+                                            }
+                                        },
+                                        {
+                                            "dep": "2019-12-24T20:10:00",
+                                            "Stn": {
+                                                "id": "vbb_900003103",
+                                                "name": "S Tiergarten",
+                                                "x": 13.336244,
+                                                "y": 52.513957
+                                            }
+                                        },
+                                        {
+                                            "dep": "2019-12-24T20:12:00",
+                                            "Stn": {
+                                                "id": "vbb_900003102",
+                                                "name": "S Bellevue",
+                                                "x": 13.347102,
+                                                "y": 52.519953
+                                            }
+                                        },
+                                        {
+                                            "dep": "2019-12-24T20:15:00",
+                                            "Stn": {
+                                                "id": "vbb_900003201",
+                                                "name": "S+U Berlin Hauptbahnhof",
+                                                "x": 13.368928,
+                                                "y": 52.52585
+                                            }
+                                        },
+                                        {
+                                            "arr": "2019-12-24T20:17:00",
+                                            "dep": "2019-12-24T20:18:00",
+                                            "Stn": {
+                                                "id": "vbb_900100001",
+                                                "name": "S+U Friedrichstr. Bhf",
+                                                "x": 13.387149,
+                                                "y": 52.520268
+                                            }
+                                        },
+                                        {
+                                            "arr": "2019-12-24T20:19:00",
+                                            "Stn": {
+                                                "id": "vbb_900100002",
+                                                "name": "S Hackescher Markt",
+                                                "x": 13.402359,
+                                                "y": 52.522605
+                                            }
+                                        }
+                                    ]
+                                },
+                                "Arr": {
+                                    "time": "2019-12-24T20:19:00",
+                                    "platform": "3",
+                                    "Stn": {
+                                        "id": "vbb_900100002",
+                                        "name": "S Hackescher Markt",
+                                        "x": 13.402359,
+                                        "y": 52.522605
+                                    }
+                                }
+                            },
+                            {
+                                "id": "R001634-C6-S5",
+                                "mode": 20,
+                                "Dep": {
+                                    "time": "2019-12-24T20:19:00",
+                                    "Stn": {
+                                        "id": "vbb_900100002",
+                                        "name": "S Hackescher Markt",
+                                        "x": 13.402359,
+                                        "y": 52.522605
+                                    },
+                                    "Transport": {
+                                        "mode": 20
+                                    }
+                                },
+                                "Journey": {
+                                    "duration": "PT5M",
+                                    "distance": 241
+                                },
+                                "Arr": {
+                                    "time": "2019-12-24T20:24:00",
+                                    "Addr": {
+                                        "x": 13.403411,
+                                        "y": 52.521436
+                                    }
+                                }
+                            }
+                        ]
+                    },
+                    "Tariff": {
+                        "Fares": [
+                            {
+                                "Fare": [
+                                    {
+                                        "name": "Regeltarif",
+                                        "currency": "EUR",
+                                        "price": 2.8,
+                                        "sec_ids": "R001634-C6-S3 R001634-C6-S4"
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                },
+                {
+                    "id": "R001634-C7",
+                    "duration": "PT9H13M0S",
+                    "transfers": 2,
+                    "Dep": {
+                        "time": "2019-12-24T14:34:00",
+                        "Addr": {
+                            "y": 49.999249,
+                            "x": 8.276387
+                        }
+                    },
+                    "Arr": {
+                        "time": "2019-12-24T23:47:00",
+                        "Addr": {
+                            "x": 13.403411,
+                            "y": 52.521436
+                        }
+                    },
+                    "Sections": {
+                        "Sec": [
+                            {
+                                "id": "R001634-C7-S0",
+                                "mode": 20,
+                                "Dep": {
+                                    "time": "2019-12-24T14:34:00",
+                                    "Addr": {
+                                        "y": 49.999249,
+                                        "x": 8.276387
+                                    },
+                                    "Transport": {
+                                        "mode": 20
+                                    }
+                                },
+                                "Journey": {
+                                    "distance": 1760,
+                                    "duration": "PT06M"
+                                },
+                                "Arr": {
+                                    "time": "2019-12-24T14:40:00",
+                                    "Stn": {
+                                        "y": 50.003314,
+                                        "x": 8.257726,
+                                        "name": "Mainz",
+                                        "id": "723881538"
+                                    }
+                                }
+                            },
+                            {
+                                "id": "R001634-C7-S1",
+                                "mode": 12,
+                                "Dep": {
+                                    "time": "2019-12-24T14:40:00",
+                                    "Stn": {
+                                        "y": 50.003314,
+                                        "x": 8.257726,
+                                        "name": "Mainz",
+                                        "id": "723881538"
+                                    },
+                                    "Transport": {
+                                        "mode": 12,
+                                        "dir": "Berlin central bus station",
+                                        "name": "FlixBus",
+                                        "At": {
+                                            "category": "Bus",
+                                            "color": "#73D700",
+                                            "textColor": "#FFFFFF",
+                                            "operator": "h2UFLI00"
+                                        }
+                                    },
+                                    "Freq": {
+                                        "min": 0,
+                                        "max": 0,
+                                        "AltDep": [
+                                            {
+                                                "time": "2019-12-24T14:40:00",
+                                                "Transport": {
+                                                    "mode": 12,
+                                                    "dir": "Berlin central bus station",
+                                                    "name": "FlixBus",
+                                                    "At": {
+                                                        "category": "Bus",
+                                                        "color": "#73D700",
+                                                        "textColor": "#FFFFFF",
+                                                        "operator": "h2UFLI00"
+                                                    }
+                                                }
+                                            },
+                                            {
+                                                "time": "2019-12-24T14:40:00",
+                                                "Transport": {
+                                                    "mode": 12,
+                                                    "dir": "Berlin central bus station",
+                                                    "name": "FlixBus",
+                                                    "At": {
+                                                        "category": "Bus",
+                                                        "color": "#73D700",
+                                                        "textColor": "#FFFFFF",
+                                                        "operator": "h2UFLI00"
+                                                    }
+                                                }
+                                            },
+                                            {
+                                                "time": "2019-12-24T14:40:00",
+                                                "Transport": {
+                                                    "mode": 12,
+                                                    "dir": "Berlin central bus station",
+                                                    "name": "FlixBus",
+                                                    "At": {
+                                                        "category": "Bus",
+                                                        "color": "#73D700",
+                                                        "textColor": "#FFFFFF",
+                                                        "operator": "h2UFLI00"
+                                                    }
+                                                }
+                                            }
+                                        ]
+                                    }
+                                },
+                                "Journey": {
+                                    "distance": 582033,
+                                    "duration": "PT08H25M",
+                                    "Stop": [
+                                        {
+                                            "dep": "2019-12-24T14:40:00",
+                                            "Stn": {
+                                                "y": 50.003314,
+                                                "x": 8.257726,
+                                                "name": "Mainz",
+                                                "id": "723881538"
+                                            }
+                                        },
+                                        {
+                                            "arr": "2019-12-24T15:20:00",
+                                            "dep": "2019-12-24T15:25:00",
+                                            "Stn": {
+                                                "y": 50.052682,
+                                                "x": 8.57749,
+                                                "name": "Frankfurt Airport",
+                                                "id": "723882424"
+                                            }
+                                        },
+                                        {
+                                            "arr": "2019-12-24T15:45:00",
+                                            "dep": "2019-12-24T16:00:00",
+                                            "Stn": {
+                                                "y": 50.104394,
+                                                "x": 8.662577,
+                                                "name": "Frankfurt, Frankfurt central station",
+                                                "id": "723881779"
+                                            }
+                                        },
+                                        {
+                                            "dep": "2019-12-24T16:25:00",
+                                            "Stn": {
+                                                "y": 50.219678,
+                                                "x": 8.621083,
+                                                "name": "Bad Homburg, Bad Homburg V.D. Höhe",
+                                                "id": "723884221"
+                                            }
+                                        },
+                                        {
+                                            "dep": "2019-12-24T17:35:00",
+                                            "Stn": {
+                                                "y": 50.732885,
+                                                "x": 9.241158,
+                                                "name": "Alsfeld, Alsfeld Pfefferhöhe",
+                                                "id": "723880027"
+                                            }
+                                        },
+                                        {
+                                            "arr": "2019-12-24T23:05:00",
+                                            "Stn": {
+                                                "y": 52.507171,
+                                                "x": 13.279399,
+                                                "name": "Berlin, Berlin central bus station",
+                                                "id": "723880688"
+                                            }
+                                        }
+                                    ]
+                                },
+                                "Arr": {
+                                    "time": "2019-12-24T23:05:00",
+                                    "Stn": {
+                                        "y": 52.507171,
+                                        "x": 13.279399,
+                                        "name": "Berlin, Berlin central bus station",
+                                        "id": "723880688"
+                                    }
+                                }
+                            },
+                            {
+                                "id": "R001634-C7-S2",
+                                "mode": 20,
+                                "Dep": {
+                                    "time": "2019-12-24T23:05:00",
+                                    "Stn": {
+                                        "x": 13.279399,
+                                        "y": 52.507171,
+                                        "id": "723880688",
+                                        "name": "Berlin, Berlin central bus station"
+                                    },
+                                    "Transport": {
+                                        "mode": 20
+                                    }
+                                },
+                                "Journey": {
+                                    "duration": "PT6M",
+                                    "distance": 316
+                                },
+                                "Arr": {
+                                    "time": "2019-12-24T23:11:00",
+                                    "Stn": {
+                                        "id": "vbb_900024106",
+                                        "name": "S Messe Nord/ICC",
+                                        "x": 13.283045,
+                                        "y": 52.506451
+                                    }
+                                }
+                            },
+                            {
+                                "id": "R001634-C7-S3",
+                                "mode": 4,
+                                "Dep": {
+                                    "time": "2019-12-24T23:20:00",
+                                    "platform": "2",
+                                    "Stn": {
+                                        "id": "vbb_900024106",
+                                        "name": "S Messe Nord/ICC",
+                                        "x": 13.283045,
+                                        "y": 52.506451
+                                    },
+                                    "Transport": {
+                                        "mode": 4,
+                                        "name": "S46",
+                                        "dir": "S Königs Wusterhausen Bhf",
+                                        "At": {
+                                            "category": "S-Bahn",
+                                            "operator": "DBS",
+                                            "textColor": "#FFFFFF",
+                                            "color": "#BF8037",
+                                            "iconId": "BERLIN_BRANDENBURG_EXT/s-bahn",
+                                            "iconShape": "RoundedRect"
+                                        }
+                                    }
+                                },
+                                "Journey": {
+                                    "duration": "PT1M",
+                                    "Stop": [
+                                        {
+                                            "dep": "2019-12-24T23:20:00",
+                                            "Stn": {
+                                                "id": "vbb_900024106",
+                                                "name": "S Messe Nord/ICC",
+                                                "x": 13.283045,
+                                                "y": 52.506451
+                                            }
+                                        },
+                                        {
+                                            "arr": "2019-12-24T23:21:00",
+                                            "Stn": {
+                                                "id": "vbb_900024102",
+                                                "name": "S Westkreuz",
+                                                "x": 13.283036,
+                                                "y": 52.501148
+                                            }
+                                        }
+                                    ]
+                                },
+                                "Arr": {
+                                    "time": "2019-12-24T23:21:00",
+                                    "platform": "12",
+                                    "Stn": {
+                                        "id": "vbb_900024102",
+                                        "name": "S Westkreuz",
+                                        "x": 13.283036,
+                                        "y": 52.501148
+                                    }
+                                }
+                            },
+                            {
+                                "id": "R001634-C7-S4",
+                                "mode": 4,
+                                "Dep": {
+                                    "time": "2019-12-24T23:25:00",
+                                    "platform": "4",
+                                    "Stn": {
+                                        "id": "vbb_900024102",
+                                        "name": "S Westkreuz",
+                                        "x": 13.283036,
+                                        "y": 52.501148
+                                    },
+                                    "Transport": {
+                                        "mode": 4,
+                                        "name": "S7",
+                                        "dir": "S Ahrensfelde Bhf",
+                                        "At": {
+                                            "category": "S-Bahn",
+                                            "operator": "DBS",
+                                            "textColor": "#FFFFFF",
+                                            "color": "#7760B0",
+                                            "iconId": "BERLIN_BRANDENBURG_EXT/s-bahn",
+                                            "iconShape": "RoundedRect"
+                                        }
+                                    }
+                                },
+                                "Journey": {
+                                    "duration": "PT17M",
+                                    "Stop": [
+                                        {
+                                            "dep": "2019-12-24T23:25:00",
+                                            "Stn": {
+                                                "id": "vbb_900024102",
+                                                "name": "S Westkreuz",
+                                                "x": 13.283036,
+                                                "y": 52.501148
+                                            }
+                                        },
+                                        {
+                                            "dep": "2019-12-24T23:27:00",
+                                            "Stn": {
+                                                "id": "vbb_900024101",
+                                                "name": "S Charlottenburg Bhf",
+                                                "x": 13.303846,
+                                                "y": 52.504806
+                                            }
+                                        },
+                                        {
+                                            "dep": "2019-12-24T23:29:00",
+                                            "Stn": {
+                                                "id": "vbb_900024203",
+                                                "name": "S Savignyplatz",
+                                                "x": 13.319002,
+                                                "y": 52.50522
+                                            }
+                                        },
+                                        {
+                                            "dep": "2019-12-24T23:31:00",
+                                            "Stn": {
+                                                "id": "vbb_900023201",
+                                                "name": "S+U Zoologischer Garten Bhf",
+                                                "x": 13.332711,
+                                                "y": 52.506919
+                                            }
+                                        },
+                                        {
+                                            "dep": "2019-12-24T23:33:00",
+                                            "Stn": {
+                                                "id": "vbb_900003103",
+                                                "name": "S Tiergarten",
+                                                "x": 13.336244,
+                                                "y": 52.513957
+                                            }
+                                        },
+                                        {
+                                            "dep": "2019-12-24T23:35:00",
+                                            "Stn": {
+                                                "id": "vbb_900003102",
+                                                "name": "S Bellevue",
+                                                "x": 13.347102,
+                                                "y": 52.519953
+                                            }
+                                        },
+                                        {
+                                            "dep": "2019-12-24T23:38:00",
+                                            "Stn": {
+                                                "id": "vbb_900003201",
+                                                "name": "S+U Berlin Hauptbahnhof",
+                                                "x": 13.368928,
+                                                "y": 52.52585
+                                            }
+                                        },
+                                        {
+                                            "arr": "2019-12-24T23:40:00",
+                                            "dep": "2019-12-24T23:41:00",
+                                            "Stn": {
+                                                "id": "vbb_900100001",
+                                                "name": "S+U Friedrichstr. Bhf",
+                                                "x": 13.387149,
+                                                "y": 52.520268
+                                            }
+                                        },
+                                        {
+                                            "arr": "2019-12-24T23:42:00",
+                                            "Stn": {
+                                                "id": "vbb_900100002",
+                                                "name": "S Hackescher Markt",
+                                                "x": 13.402359,
+                                                "y": 52.522605
+                                            }
+                                        }
+                                    ]
+                                },
+                                "Arr": {
+                                    "time": "2019-12-24T23:42:00",
+                                    "platform": "3",
+                                    "Stn": {
+                                        "id": "vbb_900100002",
+                                        "name": "S Hackescher Markt",
+                                        "x": 13.402359,
+                                        "y": 52.522605
+                                    }
+                                }
+                            },
+                            {
+                                "id": "R001634-C7-S5",
+                                "mode": 20,
+                                "Dep": {
+                                    "time": "2019-12-24T23:42:00",
+                                    "Stn": {
+                                        "id": "vbb_900100002",
+                                        "name": "S Hackescher Markt",
+                                        "x": 13.402359,
+                                        "y": 52.522605
+                                    },
+                                    "Transport": {
+                                        "mode": 20
+                                    }
+                                },
+                                "Journey": {
+                                    "duration": "PT5M",
+                                    "distance": 241
+                                },
+                                "Arr": {
+                                    "time": "2019-12-24T23:47:00",
+                                    "Addr": {
+                                        "x": 13.403411,
+                                        "y": 52.521436
+                                    }
+                                }
+                            }
+                        ]
+                    },
+                    "Tariff": {
+                        "Fares": [
+                            {
+                                "Fare": [
+                                    {
+                                        "name": "Regeltarif",
+                                        "currency": "EUR",
+                                        "price": 2.8,
+                                        "sec_ids": "R001634-C7-S3 R001634-C7-S4"
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                },
+                {
+                    "id": "R001634-C8",
+                    "duration": "PT8H43M0S",
+                    "transfers": 2,
+                    "Dep": {
+                        "time": "2019-12-24T11:44:00",
+                        "Addr": {
+                            "y": 49.999249,
+                            "x": 8.276387
+                        }
+                    },
+                    "Arr": {
+                        "time": "2019-12-24T20:27:00",
+                        "Addr": {
+                            "x": 13.403411,
+                            "y": 52.521436
+                        }
+                    },
+                    "Sections": {
+                        "Sec": [
+                            {
+                                "id": "R001634-C8-S0",
+                                "mode": 20,
+                                "Dep": {
+                                    "time": "2019-12-24T11:44:00",
+                                    "Addr": {
+                                        "y": 49.999249,
+                                        "x": 8.276387
+                                    },
+                                    "Transport": {
+                                        "mode": 20
+                                    }
+                                },
+                                "Journey": {
+                                    "distance": 1760,
+                                    "duration": "PT06M"
+                                },
+                                "Arr": {
+                                    "time": "2019-12-24T11:50:00",
+                                    "Stn": {
+                                        "y": 50.003314,
+                                        "x": 8.257726,
+                                        "name": "Mainz",
+                                        "id": "723881538"
+                                    }
+                                }
+                            },
+                            {
+                                "id": "R001634-C8-S1",
+                                "mode": 12,
+                                "Dep": {
+                                    "time": "2019-12-24T11:50:00",
+                                    "Stn": {
+                                        "y": 50.003314,
+                                        "x": 8.257726,
+                                        "name": "Mainz",
+                                        "id": "723881538"
+                                    },
+                                    "Transport": {
+                                        "mode": 12,
+                                        "dir": "Berlin central bus station",
+                                        "name": "FlixBus",
+                                        "At": {
+                                            "category": "Bus",
+                                            "color": "#73D700",
+                                            "textColor": "#FFFFFF",
+                                            "operator": "h2UFLI00"
+                                        }
+                                    },
+                                    "Freq": {
+                                        "min": 0,
+                                        "max": 0,
+                                        "AltDep": [
+                                            {
+                                                "time": "2019-12-24T11:50:00",
+                                                "Transport": {
+                                                    "mode": 12,
+                                                    "dir": "Berlin central bus station",
+                                                    "name": "FlixBus",
+                                                    "At": {
+                                                        "category": "Bus",
+                                                        "color": "#73D700",
+                                                        "textColor": "#FFFFFF",
+                                                        "operator": "h2UFLI00"
+                                                    }
+                                                }
+                                            }
+                                        ]
+                                    }
+                                },
+                                "Journey": {
+                                    "distance": 582259,
+                                    "duration": "PT07H50M",
+                                    "Stop": [
+                                        {
+                                            "dep": "2019-12-24T11:50:00",
+                                            "Stn": {
+                                                "y": 50.003314,
+                                                "x": 8.257726,
+                                                "name": "Mainz",
+                                                "id": "723881538"
+                                            }
+                                        },
+                                        {
+                                            "arr": "2019-12-24T12:25:00",
+                                            "dep": "2019-12-24T12:30:00",
+                                            "Stn": {
+                                                "y": 50.052682,
+                                                "x": 8.57749,
+                                                "name": "Frankfurt Airport",
+                                                "id": "723882424"
+                                            }
+                                        },
+                                        {
+                                            "arr": "2019-12-24T12:50:00",
+                                            "dep": "2019-12-24T13:05:00",
+                                            "Stn": {
+                                                "y": 50.104394,
+                                                "x": 8.662577,
+                                                "name": "Frankfurt, Frankfurt central station",
+                                                "id": "723881779"
+                                            }
+                                        },
+                                        {
+                                            "arr": "2019-12-24T14:50:00",
+                                            "dep": "2019-12-24T14:55:00",
+                                            "Stn": {
+                                                "y": 50.868874,
+                                                "x": 9.715226,
+                                                "name": "Bad Hersfeld, Bad Hersfeld, station",
+                                                "id": "723882158"
+                                            }
+                                        },
+                                        {
+                                            "arr": "2019-12-24T19:40:00",
+                                            "Stn": {
+                                                "y": 52.507171,
+                                                "x": 13.279399,
+                                                "name": "Berlin, Berlin central bus station",
+                                                "id": "723880688"
+                                            }
+                                        }
+                                    ]
+                                },
+                                "Arr": {
+                                    "time": "2019-12-24T19:40:00",
+                                    "Stn": {
+                                        "y": 52.507171,
+                                        "x": 13.279399,
+                                        "name": "Berlin, Berlin central bus station",
+                                        "id": "723880688"
+                                    }
+                                }
+                            },
+                            {
+                                "id": "R001634-C8-S2",
+                                "mode": 20,
+                                "Dep": {
+                                    "time": "2019-12-24T19:40:00",
+                                    "Stn": {
+                                        "x": 13.279399,
+                                        "y": 52.507171,
+                                        "id": "723880688",
+                                        "name": "Berlin, Berlin central bus station"
+                                    },
+                                    "Transport": {
+                                        "mode": 20
+                                    }
+                                },
+                                "Journey": {
+                                    "duration": "PT6M",
+                                    "distance": 316
+                                },
+                                "Arr": {
+                                    "time": "2019-12-24T19:46:00",
+                                    "Stn": {
+                                        "id": "vbb_900024106",
+                                        "name": "S Messe Nord/ICC",
+                                        "x": 13.283045,
+                                        "y": 52.506451
+                                    }
+                                }
+                            },
+                            {
+                                "id": "R001634-C8-S3",
+                                "mode": 4,
+                                "Dep": {
+                                    "time": "2019-12-24T20:00:00",
+                                    "platform": "2",
+                                    "Stn": {
+                                        "id": "vbb_900024106",
+                                        "name": "S Messe Nord/ICC",
+                                        "x": 13.283045,
+                                        "y": 52.506451
+                                    },
+                                    "Transport": {
+                                        "mode": 4,
+                                        "name": "S46",
+                                        "dir": "S Königs Wusterhausen Bhf",
+                                        "At": {
+                                            "category": "S-Bahn",
+                                            "operator": "DBS",
+                                            "textColor": "#FFFFFF",
+                                            "color": "#BF8037",
+                                            "iconId": "BERLIN_BRANDENBURG_EXT/s-bahn",
+                                            "iconShape": "RoundedRect"
+                                        }
+                                    }
+                                },
+                                "Journey": {
+                                    "duration": "PT1M",
+                                    "Stop": [
+                                        {
+                                            "dep": "2019-12-24T20:00:00",
+                                            "Stn": {
+                                                "id": "vbb_900024106",
+                                                "name": "S Messe Nord/ICC",
+                                                "x": 13.283045,
+                                                "y": 52.506451
+                                            }
+                                        },
+                                        {
+                                            "arr": "2019-12-24T20:01:00",
+                                            "Stn": {
+                                                "id": "vbb_900024102",
+                                                "name": "S Westkreuz",
+                                                "x": 13.283036,
+                                                "y": 52.501148
+                                            }
+                                        }
+                                    ]
+                                },
+                                "Arr": {
+                                    "time": "2019-12-24T20:01:00",
+                                    "platform": "12",
+                                    "Stn": {
+                                        "id": "vbb_900024102",
+                                        "name": "S Westkreuz",
+                                        "x": 13.283036,
+                                        "y": 52.501148
+                                    }
+                                }
+                            },
+                            {
+                                "id": "R001634-C8-S4",
+                                "mode": 4,
+                                "Dep": {
+                                    "time": "2019-12-24T20:05:00",
+                                    "platform": "4",
+                                    "Stn": {
+                                        "id": "vbb_900024102",
+                                        "name": "S Westkreuz",
+                                        "x": 13.283036,
+                                        "y": 52.501148
+                                    },
+                                    "Transport": {
+                                        "mode": 4,
+                                        "name": "S7",
+                                        "dir": "S Ahrensfelde Bhf",
+                                        "At": {
+                                            "category": "S-Bahn",
+                                            "operator": "DBS",
+                                            "textColor": "#FFFFFF",
+                                            "color": "#7760B0",
+                                            "iconId": "BERLIN_BRANDENBURG_EXT/s-bahn",
+                                            "iconShape": "RoundedRect"
+                                        }
+                                    }
+                                },
+                                "Journey": {
+                                    "duration": "PT17M",
+                                    "Stop": [
+                                        {
+                                            "dep": "2019-12-24T20:05:00",
+                                            "Stn": {
+                                                "id": "vbb_900024102",
+                                                "name": "S Westkreuz",
+                                                "x": 13.283036,
+                                                "y": 52.501148
+                                            }
+                                        },
+                                        {
+                                            "dep": "2019-12-24T20:07:00",
+                                            "Stn": {
+                                                "id": "vbb_900024101",
+                                                "name": "S Charlottenburg Bhf",
+                                                "x": 13.303846,
+                                                "y": 52.504806
+                                            }
+                                        },
+                                        {
+                                            "dep": "2019-12-24T20:09:00",
+                                            "Stn": {
+                                                "id": "vbb_900024203",
+                                                "name": "S Savignyplatz",
+                                                "x": 13.319002,
+                                                "y": 52.50522
+                                            }
+                                        },
+                                        {
+                                            "dep": "2019-12-24T20:11:00",
+                                            "Stn": {
+                                                "id": "vbb_900023201",
+                                                "name": "S+U Zoologischer Garten Bhf",
+                                                "x": 13.332711,
+                                                "y": 52.506919
+                                            }
+                                        },
+                                        {
+                                            "dep": "2019-12-24T20:13:00",
+                                            "Stn": {
+                                                "id": "vbb_900003103",
+                                                "name": "S Tiergarten",
+                                                "x": 13.336244,
+                                                "y": 52.513957
+                                            }
+                                        },
+                                        {
+                                            "dep": "2019-12-24T20:15:00",
+                                            "Stn": {
+                                                "id": "vbb_900003102",
+                                                "name": "S Bellevue",
+                                                "x": 13.347102,
+                                                "y": 52.519953
+                                            }
+                                        },
+                                        {
+                                            "dep": "2019-12-24T20:18:00",
+                                            "Stn": {
+                                                "id": "vbb_900003201",
+                                                "name": "S+U Berlin Hauptbahnhof",
+                                                "x": 13.368928,
+                                                "y": 52.52585
+                                            }
+                                        },
+                                        {
+                                            "arr": "2019-12-24T20:20:00",
+                                            "dep": "2019-12-24T20:21:00",
+                                            "Stn": {
+                                                "id": "vbb_900100001",
+                                                "name": "S+U Friedrichstr. Bhf",
+                                                "x": 13.387149,
+                                                "y": 52.520268
+                                            }
+                                        },
+                                        {
+                                            "arr": "2019-12-24T20:22:00",
+                                            "Stn": {
+                                                "id": "vbb_900100002",
+                                                "name": "S Hackescher Markt",
+                                                "x": 13.402359,
+                                                "y": 52.522605
+                                            }
+                                        }
+                                    ]
+                                },
+                                "Arr": {
+                                    "time": "2019-12-24T20:22:00",
+                                    "platform": "3",
+                                    "Stn": {
+                                        "id": "vbb_900100002",
+                                        "name": "S Hackescher Markt",
+                                        "x": 13.402359,
+                                        "y": 52.522605
+                                    }
+                                }
+                            },
+                            {
+                                "id": "R001634-C8-S5",
+                                "mode": 20,
+                                "Dep": {
+                                    "time": "2019-12-24T20:22:00",
+                                    "Stn": {
+                                        "id": "vbb_900100002",
+                                        "name": "S Hackescher Markt",
+                                        "x": 13.402359,
+                                        "y": 52.522605
+                                    },
+                                    "Transport": {
+                                        "mode": 20
+                                    }
+                                },
+                                "Journey": {
+                                    "duration": "PT5M",
+                                    "distance": 241
+                                },
+                                "Arr": {
+                                    "time": "2019-12-24T20:27:00",
+                                    "Addr": {
+                                        "x": 13.403411,
+                                        "y": 52.521436
+                                    }
+                                }
+                            }
+                        ]
+                    },
+                    "Tariff": {
+                        "Fares": [
+                            {
+                                "Fare": [
+                                    {
+                                        "name": "Regeltarif",
+                                        "currency": "EUR",
+                                        "price": 2.8,
+                                        "sec_ids": "R001634-C8-S3 R001634-C8-S4"
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                }
+            ],
+            "Operators": {
+                "Op": [
+                    {
+                        "code": "DB",
+                        "name": "Deutsche Bahn",
+                        "type": "TT"
+                    },
+                    {
+                        "code": "h2UFLI00",
+                        "type": "TT",
+                        "name": "FlixBus",
+                        "short_name": "FLI",
+                        "Link": [
+                            {
+                                "type": "website",
+                                "href": "https://transit.ls.hereapi.com/r?appId=DnGL1N8b2VU6NPRwJWqE&u=https://www.flixbus.com/?wt_mc=earned.earned.earned.maps.ndovloket.ndovloket.ndovloket.ad%26utm_medium=organic%26utm_source=ndovloket",
+                                "sec_ids": "R001634-C6-S1 R001634-C8-S1 R001634-C7-S1",
+                                "text": "FlixBus"
+                            }
+                        ]
+                    },
+                    {
+                        "type": "RT",
+                        "code": "DBS",
+                        "name": "S-Bahn Berlin GmbH"
+                    }
+                ]
+            },
+            "Attributions": {
+                "Link": [
+                    {
+                        "href": "https://transit.ls.hereapi.com/r?appId=DnGL1N8b2VU6NPRwJWqE&u=http://www.bahn.de",
+                        "type": "agency",
+                        "sec_ids": "R001634-C0-S1 R001634-C0-S2 R001634-C0-S3 R001634-C0-S5 R001634-C1-S1 R001634-C1-S2 R001634-C1-S4 R001634-C2-S1 R001634-C2-S2 R001634-C2-S4 R001634-C3-S1 R001634-C3-S3 R001634-C3-S4 R001634-C3-S6 R001634-C4-S1 R001634-C4-S3 R001634-C4-S4 R001634-C4-S5 R001634-C4-S7 R001634-C5-S1 R001634-C5-S3 R001634-C5-S4 R001634-C5-S6",
+                        "text": "Powered by bahn.de"
+                    },
+                    {
+                        "href": "https://transit.ls.hereapi.com/r?appId=DnGL1N8b2VU6NPRwJWqE&u=https://mobile.bahn.de/bin/mobil/query.exe/dox?S=Mainz%20R%C3%B6misches%20Theater%26Z=Berlin%20Hackescher%20Markt%26date=24.12.2019%26dbkanal_004=L01_S01_D001_KPK0072_Anreise_LZ03%26time=11:14",
+                        "type": "tariff",
+                        "sec_ids": "R001634-C0-S1 R001634-C0-S2 R001634-C0-S3 R001634-C0-S5",
+                        "text": "bahn.de"
+                    },
+                    {
+                        "href": "https://transit.ls.hereapi.com/r?appId=DnGL1N8b2VU6NPRwJWqE&u=https://mobile.bahn.de/bin/mobil/query.exe/dox?S=Mainz%20Hbf%26Z=Berlin%20Hackescher%20Markt%26date=24.12.2019%26dbkanal_004=L01_S01_D001_KPK0072_Anreise_LZ03%26time=11:42",
+                        "type": "tariff",
+                        "sec_ids": "R001634-C1-S1 R001634-C1-S2 R001634-C1-S4",
+                        "text": "bahn.de"
+                    },
+                    {
+                        "href": "https://transit.ls.hereapi.com/r?appId=DnGL1N8b2VU6NPRwJWqE&u=https://mobile.bahn.de/bin/mobil/query.exe/dox?S=Mainz-Kastel%26Z=Berlin%20Hackescher%20Markt%26date=24.12.2019%26dbkanal_004=L01_S01_D001_KPK0072_Anreise_LZ03%26time=11:39",
+                        "type": "tariff",
+                        "sec_ids": "R001634-C2-S1 R001634-C2-S2 R001634-C2-S4",
+                        "text": "bahn.de"
+                    },
+                    {
+                        "href": "https://transit.ls.hereapi.com/r?appId=DnGL1N8b2VU6NPRwJWqE&u=https://mobile.bahn.de/bin/mobil/query.exe/dox?S=Fischtor%2C%20Mainz%26Z=Berlin%20Hackescher%20Markt%26date=24.12.2019%26dbkanal_004=L01_S01_D001_KPK0072_Anreise_LZ03%26time=11:25",
+                        "type": "tariff",
+                        "sec_ids": "R001634-C3-S1 R001634-C3-S3 R001634-C3-S4 R001634-C3-S6",
+                        "text": "bahn.de"
+                    },
+                    {
+                        "href": "https://transit.ls.hereapi.com/r?appId=DnGL1N8b2VU6NPRwJWqE&u=https://mobile.bahn.de/bin/mobil/query.exe/dox?S=Rheingoldhalle/Rathaus%2C%20Mainz%26Z=Berlin%20Hackescher%20Markt%26date=24.12.2019%26dbkanal_004=L01_S01_D001_KPK0072_Anreise_LZ03%26time=11:30",
+                        "type": "tariff",
+                        "sec_ids": "R001634-C4-S1 R001634-C4-S3 R001634-C4-S4 R001634-C4-S5 R001634-C4-S7 R001634-C5-S1 R001634-C5-S3 R001634-C5-S4 R001634-C5-S6",
+                        "text": "bahn.de"
+                    },
+                    {
+                        "type": "agency",
+                        "href": "https://transit.ls.hereapi.com/r?appId=DnGL1N8b2VU6NPRwJWqE&u=https://flixbus.com",
+                        "sec_ids": "R001634-C6-S1 R001634-C8-S1 R001634-C7-S1",
+                        "text": "Information for public transit provided by FlixMobility GmbH"
+                    }
+                ]
+            }
+        }
+    }
+}

--- a/tests/test_enum.py
+++ b/tests/test_enum.py
@@ -48,12 +48,10 @@ class PublicTransitSearchMethodTest(unittest.TestCase):
         strict = herepy.PublicTransitSearchMethod.strict
         self.assertEqual(strict.__str__(), 'strict')
 
-class PublicTransitRoutingTypeTest(unittest.TestCase):
+class PublicTransitRoutingModeTest(unittest.TestCase):
 
     def test_valueofenum(self):
-        time_tabled = herepy.PublicTransitRoutingType.time_tabled
-        self.assertEqual(time_tabled.__str__(), 'tt')
-        simple = herepy.PublicTransitRoutingType.simple
-        self.assertEqual(simple.__str__(), 'sr')
-        all = herepy.PublicTransitRoutingType.all
-        self.assertEqual(all.__str__(), 'all')
+        schedule = herepy.PublicTransitRoutingMode.schedule
+        self.assertEqual(schedule.__str__(), 'schedule')
+        realtime = herepy.PublicTransitRoutingMode.realtime
+        self.assertEqual(realtime.__str__(), 'realtime')

--- a/tests/test_enum.py
+++ b/tests/test_enum.py
@@ -48,6 +48,42 @@ class PublicTransitSearchMethodTest(unittest.TestCase):
         strict = herepy.PublicTransitSearchMethod.strict
         self.assertEqual(strict.__str__(), 'strict')
 
+class PublicTransitModeTypeTest(unittest.TestCase):
+
+    def test_valueofenum(self):
+        high_speed_train = herepy.PublicTransitModeType.high_speed_train
+        self.assertEqual(high_speed_train.__str__(), "0")
+        intercity_train = herepy.PublicTransitModeType.intercity_train
+        self.assertEqual(intercity_train.__str__(), "1")
+        inter_regional_train = herepy.PublicTransitModeType.inter_regional_train
+        self.assertEqual(inter_regional_train.__str__(), "2")
+        regional_train = herepy.PublicTransitModeType.regional_train
+        self.assertEqual(regional_train.__str__(), "3")
+        city_train = herepy.PublicTransitModeType.city_train
+        self.assertEqual(city_train.__str__(), "4")
+        bus = herepy.PublicTransitModeType.bus
+        self.assertEqual(bus.__str__(), "5")
+        ferry = herepy.PublicTransitModeType.ferry
+        self.assertEqual(ferry.__str__(), "6")
+        subway = herepy.PublicTransitModeType.subway
+        self.assertEqual(subway.__str__(), "7")
+        light_rail = herepy.PublicTransitModeType.light_rail
+        self.assertEqual(light_rail.__str__(), "8")
+        private_bus = herepy.PublicTransitModeType.private_bus
+        self.assertEqual(private_bus.__str__(), "9")
+        inclined = herepy.PublicTransitModeType.inclined
+        self.assertEqual(inclined.__str__(), "10")
+        aerial = herepy.PublicTransitModeType.aerial
+        self.assertEqual(aerial.__str__(), "11")
+        bus_rapid = herepy.PublicTransitModeType.bus_rapid
+        self.assertEqual(bus_rapid.__str__(), "12")
+        monorail = herepy.PublicTransitModeType.monorail
+        self.assertEqual(monorail.__str__(), "13")
+        flight = herepy.PublicTransitModeType.flight
+        self.assertEqual(flight.__str__(), "14")
+        walk = herepy.PublicTransitModeType.walk
+        self.assertEqual(walk.__str__(), "20")
+
 class PublicTransitRoutingModeTest(unittest.TestCase):
 
     def test_valueofenum(self):

--- a/tests/test_publictransit_api.py
+++ b/tests/test_publictransit_api.py
@@ -189,6 +189,20 @@ class PublicTransitApiTest(unittest.TestCase):
         self.assertIsInstance(response, herepy.PublicTransitResponse)
 
     @responses.activate
+    def test_calculate_route_short_route(self):
+        with io.open('testdata/models/public_transit_api_calculate_route_many_transfers.json', 'r', encoding='utf-8') as f:
+            expectedResponse = f.read()
+        responses.add(responses.GET, 'https://transit.ls.hereapi.com/v3/route.json',
+                  expectedResponse, status=200)
+        expected_short_route = ("RE 29511 - Frankfurt(Main)Hbf; ICE 76 - Hamburg-Altona; "
+            "ICE 849 - Berlin Gesundbrunnen; S5 - Strausberg Nord")
+        response = self._api.calculate_route([41.9773, -87.9019], [41.8961, -87.6552], '2017-11-22T07:30:00')
+        short_route = response.Res["Connections"]["Connection"][0]["short_route"]
+        self.assertTrue(response)
+        self.assertIsInstance(response, herepy.PublicTransitResponse)
+        self.assertEqual(short_route, expected_short_route)
+
+    @responses.activate
     def test_calculate_route_whenerroroccured(self):
         with open('testdata/models/public_transit_api_error.json', 'r') as f:
             expectedResponse = f.read()
@@ -234,26 +248,3 @@ class PublicTransitApiTest(unittest.TestCase):
                   expectedResponse, status=200)
         with self.assertRaises(herepy.HEREError):
             self._api.coverage_nearby(0, [-9999, -9999])
-
-    @responses.activate
-    def test_route_excluding_changes_transfers_whensucceed(self):
-        with io.open('testdata/models/public_transit_api_router_exclude_changes.json', 'r', encoding='utf-8') as f:
-            expectedResponse = f.read()
-        responses.add(responses.GET, 'https://transit.ls.hereapi.com/v3/route.json',
-                  expectedResponse, status=200)
-        response = self._api.route_excluding_changes_transfers([40.752470, -73.97800],
-                                                               [40.750501, -73.99351],
-                                                               '2017-12-11T07:30:00')
-        self.assertTrue(response)
-        self.assertIsInstance(response, herepy.PublicTransitResponse)
-
-    @responses.activate
-    def test_croute_excluding_changes_transfers_whenerroroccured(self):
-        with open('testdata/models/public_transit_api_error.json', 'r') as f:
-            expectedResponse = f.read()
-        responses.add(responses.GET, 'https://transit.ls.hereapi.com/v3/route.json',
-                  expectedResponse, status=200)
-        with self.assertRaises(herepy.HEREError):
-            self._api.route_excluding_changes_transfers([-9998, -9998],
-                                                        [-9999, -9999],
-                                                        '2017-12-11T07:30:00')

--- a/tests/test_publictransit_api.py
+++ b/tests/test_publictransit_api.py
@@ -162,7 +162,29 @@ class PublicTransitApiTest(unittest.TestCase):
             expectedResponse = f.read()
         responses.add(responses.GET, 'https://transit.ls.hereapi.com/v3/route.json',
                   expectedResponse, status=200)
-        response = self._api.calculate_route([41.9773, -87.9019], [41.8961, -87.6552], '2017-11-22T07:30:00', herepy.PublicTransitRoutingType.time_tabled)
+        response = self._api.calculate_route([41.9773, -87.9019], [41.8961, -87.6552], '2017-11-22T07:30:00')
+        self.assertTrue(response)
+        self.assertIsInstance(response, herepy.PublicTransitResponse)
+
+    @responses.activate
+    def test_calculate_route_include_modes(self):
+        with io.open('testdata/models/public_transit_calculate_route.json', 'r', encoding='utf-8') as f:
+            expectedResponse = f.read()
+        responses.add(responses.GET, 'https://transit.ls.hereapi.com/v3/route.json',
+                  expectedResponse, status=200)
+        include_modes = [herepy.PublicTransitModeType.bus, herepy.PublicTransitModeType.city_train]
+        response = self._api.calculate_route([41.9773, -87.9019], [41.8961, -87.6552], '2017-11-22T07:30:00', include_modes=include_modes)
+        self.assertTrue(response)
+        self.assertIsInstance(response, herepy.PublicTransitResponse)
+
+    @responses.activate
+    def test_calculate_route_exclude_modes(self):
+        with io.open('testdata/models/public_transit_calculate_route.json', 'r', encoding='utf-8') as f:
+            expectedResponse = f.read()
+        responses.add(responses.GET, 'https://transit.ls.hereapi.com/v3/route.json',
+                  expectedResponse, status=200)
+        exclude_modes = [herepy.PublicTransitModeType.bus, herepy.PublicTransitModeType.city_train]
+        response = self._api.calculate_route([41.9773, -87.9019], [41.8961, -87.6552], '2017-11-22T07:30:00', exclude_modes=exclude_modes)
         self.assertTrue(response)
         self.assertIsInstance(response, herepy.PublicTransitResponse)
 
@@ -173,57 +195,7 @@ class PublicTransitApiTest(unittest.TestCase):
         responses.add(responses.GET, 'https://transit.ls.hereapi.com/v3/route.json',
                   expectedResponse, status=200)
         with self.assertRaises(herepy.HEREError):
-            self._api.calculate_route([-9999, -9999], [-9999, -9999], '2017-11-22T07:30:00', herepy.PublicTransitRoutingType.time_tabled)
-
-    @responses.activate
-    def test_calculate_route_time_whensucceed(self):
-        with io.open('testdata/models/public_transit_api_calculate_route_time.json', 'r', encoding='utf-8') as f:
-            expectedResponse = f.read()
-        responses.add(responses.GET, 'https://transit.ls.hereapi.com/v3/route.json',
-                  expectedResponse, status=200)
-        response = self._api.calculate_route_time([41.9773, -87.9019],
-                                                  [41.8961, -87.6552],
-                                                  '2017-11-22T07:30:00',
-                                                  1,
-                                                  herepy.PublicTransitRoutingType.time_tabled)
-        self.assertTrue(response)
-        self.assertIsInstance(response, herepy.PublicTransitResponse)
-
-    @responses.activate
-    def test_calculate_route_time_whenerroroccured(self):
-        with open('testdata/models/public_transit_api_error.json', 'r') as f:
-            expectedResponse = f.read()
-        responses.add(responses.GET, 'https://transit.ls.hereapi.com/v3/route.json',
-                  expectedResponse, status=200)
-        with self.assertRaises(herepy.HEREError):
-            self._api.calculate_route_time([-9999, -9999],
-                                           [-9999, -9999],
-                                           '2017-11-22T07:30:00',
-                                           1,
-                                           herepy.PublicTransitRoutingType.time_tabled)
-
-    @responses.activate
-    def test_transit_route_shows_line_graph_whensucceed(self):
-        with io.open('testdata/models/public_transit_api_calculate_route_time.json', 'r', encoding='utf-8') as f:
-            expectedResponse = f.read()
-        responses.add(responses.GET, 'https://transit.ls.hereapi.com/v3/route.json',
-                  expectedResponse, status=200)
-        response = self._api.transit_route_shows_line_graph([41.9773, -87.9019],
-                                                            [41.8961, -87.6552],
-                                                            '2017-11-22T07:30:00',)
-        self.assertTrue(response)
-        self.assertIsInstance(response, herepy.PublicTransitResponse)
-
-    @responses.activate
-    def test_transit_route_shows_line_graph_whenerroroccured(self):
-        with open('testdata/models/public_transit_api_error.json', 'r') as f:
-            expectedResponse = f.read()
-        responses.add(responses.GET, 'https://transit.ls.hereapi.com/v3/route.json',
-                  expectedResponse, status=200)
-        with self.assertRaises(herepy.HEREError):
-            self._api.transit_route_shows_line_graph([-9999, -9999],
-                                                     [-9999, -9999],
-                                                     '2017-11-22T07:30:00')
+            self._api.calculate_route([-9999, -9999], [-9999, -9999], '2017-11-22T07:30:00')
 
     @responses.activate
     def test_coverage_witin_a_city_whensucceed(self):


### PR DESCRIPTION
Provide all options for calculate_route which might be of interest for downstream libs.

# Breaking changes:

## Removed transit_route_shows_line_graph

Use `calculate_route()` with parameter `graph=True` instead

## Removed calculate_route_time

In default mode the returned timestamps are the arrival times. If you want to get the timestamps for the departures times use  `calculate_route()` with parameter `show_arrival_times=False` instead

## Removed route_excluding_changes_transfers

Use `calculate_route()` with parameter `changes=0` instead

## PublicTransitRoutingType deprecated

Only the new `PublicTransitRoutingMode` with `schedule` and `realtime` is supported by the API.