### PR TITLE
Update routing_api.py

### DIFF
--- a/herepy/routing_api.py
+++ b/herepy/routing_api.py
@@ -458,8 +458,9 @@ class RoutingApi(HEREApi):
             "destination": str.format("{0},{1}", destination[0], destination[1]),
             "apiKey": self._api_key,
         }
+
+        via_keys = []
         if via:
-            via_keys = []
             for i, v in enumerate(via):
                 key = str.format("{0}{1}", "via", i)
                 via_keys.append(key)


### PR DESCRIPTION
Hi there.

I faced this issue that when I am not passing the `via` attribute to the `route_v8` function, an error is occurred `via_keys used before assigning`.

And here is a pretty simple fix.