### PR TITLE
Switch to constraint

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-requests==2.25.1
+requests>=2.25.1,<3


### PR DESCRIPTION
The pinning may cause trouble as Home Assistant want [`requests==2.26.0`](https://github.com/home-assistant/core/blob/dev/requirements.txt#L20). Also, distributions usually try to ship the latest release of a module.