### PR TITLE
Add py.typed file to allow mypy to use type annotations

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,6 +39,7 @@ setup(
     url=extract_metaitem('url'),
     download_url=extract_metaitem('download_url'),
     packages=find_packages(exclude=('tests', 'docs')),
+    package_data={"herepy": ["py.typed"]},
     platforms=['Any'],
     python_requires=">=3.5",
     install_requires=requirements,


### PR DESCRIPTION
This adds a py.typed file to fix #69, meaning that downstream users with mypy will have type checking against HerePy's existing type annotations.