### PR TITLE
Update geocoder_api.py to handle optional city, country and postal code

### DIFF
--- a/herepy/geocoder_api.py
+++ b/herepy/geocoder_api.py
@@ -106,11 +106,12 @@ class GeocoderApi(HEREApi):
 
     def address_with_details(
         self,
-        city: str,
-        country: str,
-        lang: str = "en-US",
         house_number: Optional[int] = None,
         street: Optional[str] = None,
+        city: Optional[str] = None,
+        postal_code: Optional[str] = None,
+        country: Optional[str] = None,
+        lang: str = "en-US",
     ) -> Optional[GeocoderResponse]:
         """Geocodes with given address details
         Args:
@@ -122,6 +123,8 @@ class GeocoderApi(HEREApi):
             city name.
           country (str):
             country name.
+          postal_code (str):
+            postal code.
           lang (str):
             BCP47 compliant Language Code.
         Returns:
@@ -129,16 +132,23 @@ class GeocoderApi(HEREApi):
         Raises:
           HEREError"""
 
-        qq_query = ""
+        qq_params = []
         if house_number is not None:
-            qq_query += f"houseNumber={house_number};"
-        if street is not None:
-            qq_query += f"street={street};"
-        qq_query += f"city={city};"
-        qq_query += f"country={country}"
+            qq_params.append(f"houseNumber={house_number}")
+        if street:
+            qq_params.append(f"street={street}")
+        if city:
+            qq_params.append(f"city={city}")
+        if postal_code:
+            qq_params.append(f"postalCode={postal_code}")
+        if country:
+            qq_params.append(f"country={country}")
+
+        if len(qq_params) == 0:
+            raise HEREError("At least one of the parameters should be provided")
 
         data = {
-            "qq": qq_query,
+            "qq": ";".join(qq_params),
             "apiKey": self._api_key,
             "lang": lang,
         }

--- a/tests/test_geocoder_api.py
+++ b/tests/test_geocoder_api.py
@@ -94,7 +94,8 @@ class GeocoderApiTest(unittest.TestCase):
             street="Barbaros",
             city="Istanbul",
             country="Turkey",
-            house_number=34
+            house_number=34,
+            postal_code="34353",
         )
         self.assertTrue(response)
         self.assertIsInstance(response, herepy.GeocoderResponse)
@@ -136,7 +137,54 @@ class GeocoderApiTest(unittest.TestCase):
         )
         self.assertTrue(response)
         self.assertIsInstance(response, herepy.GeocoderResponse)
-        
+
+    @responses.activate
+    def test_address_with_detail_without_country(self):
+        with open("testdata/models/geocoder.json", "r") as f:
+            expected_response = f.read()
+        responses.add(
+            responses.GET,
+            "https://geocode.search.hereapi.com/v1/geocode",
+            expected_response,
+            status=200,
+        )
+        response = self._api.address_with_details(
+            street="Barbaros",
+            city="Istanbul",
+            country= None
+        )
+        self.assertTrue(response)
+        self.assertIsInstance(response, herepy.GeocoderResponse)
+
+    @responses.activate
+    def test_address_with_detail_with_only_country(self):
+        with open("testdata/models/geocoder.json") as f:
+            expected_response = f.read()
+        responses.add(
+            responses.GET,
+            "https://geocode.search.hereapi.com/v1/geocode",
+            expected_response,
+            status=200,
+        )
+        response = self._api.address_with_details(
+            country="FR",
+        )
+        self.assertTrue(response)
+        self.assertIsInstance(response, herepy.GeocoderResponse)
+
+    @responses.activate
+    def test_address_with_detail_without_any_detail_raise(self):
+        with open("testdata/models/geocoder.json") as f:
+            expected_response = f.read()
+        responses.add(
+            responses.GET,
+            "https://geocode.search.hereapi.com/v1/geocode",
+            expected_response,
+            status=200,
+        )
+        with self.assertRaises(herepy.HEREError):
+            self._api.address_with_details(country="")
+
     @responses.activate
     def test_addresswithdetails_whenerroroccurred(self):
         with open("testdata/models/geocoder_error.json", "r") as f:


### PR DESCRIPTION
As in #77, this PR extends `address_with_details`:
- `city` is now optional
- `country` is now optional
- `postal_code` has been added
- If nothing is provided (since now all parameters can be optional), raise an error before doing a request that would be rejected
- Treat empty strings as None because here will fail anyway
