### PR TITLE
[FIX] Multiple parameters for route_v8

### DIFF
--- a/herepy/routing_api.py
+++ b/herepy/routing_api.py
@@ -457,17 +457,9 @@ class RoutingApi(HEREApi):
         if alternatives:
             data["alternatives"] = alternatives
         if avoid:
-            key = list(avoid.keys())[0]
-            values = list(avoid.values())[0]
-            data["avoid"] = {
-                key: ",".join(values),
-            }
+            data["avoid"] = {key: ",".join(vals) for key, vals in avoid.items()}
         if exclude:
-            key = list(exclude.keys())[0]
-            values = list(exclude.values())[0]
-            data["exclude"] = {
-                key: ",".join(values),
-            }
+            data["exclude"] = {key: ",".join(vals) for key, vals in exclude.items()}
         if units:
             data["units"] = units.__str__()
         if lang:
@@ -477,11 +469,7 @@ class RoutingApi(HEREApi):
         if span_fields:
             data["spans"] = ",".join([field.__str__() for field in span_fields])
         if truck:
-            key = list(truck.keys())[0]
-            values = list(truck.values())[0]
-            data["truck"] = {
-                key: ",".join(values),
-            }
+            data["truck"] = {key: ",".join(vals) for key, vals in truck.items()}
         if scooter:
             data["scooter"] = scooter
 

--- a/herepy/utils.py
+++ b/herepy/utils.py
@@ -18,16 +18,23 @@ class Utils(object):
           parameters (dict):
             dictionary of query parameters to be converted.
         Returns:
-          A URL-encoded string in "key=value&key=value" form
+          A URL-encoded string in "key=value&key=value" form. If the parameter value is
+            a dict, the encoded string is converted to "main_key[sub_key]=sub_value".
         """
         if parameters is None:
             return None
         if not isinstance(parameters, dict):
             raise HEREError("`parameters` must be a dict.")
         else:
-            return urlencode(
-                dict((k, v) for k, v in parameters.items() if v is not None)
-            )
+            parameters = dict((k, v) for k, v in parameters.items() if v is not None)
+            result = dict()
+            for key, value in parameters.items():
+                if isinstance(value, dict):
+                    for sub_key, sub_value in value.items():
+                        result[f"{key}[{sub_key}]"] = sub_value
+                else:
+                    result[key] = value
+            return urlencode(result)
 
     @staticmethod
     def build_url(url, extra_params=None):

--- a/tests/test_routing_api.py
+++ b/tests/test_routing_api.py
@@ -1215,3 +1215,22 @@ class RoutingApiTest(unittest.TestCase):
         )
         self.assertTrue(response)
         self.assertIsInstance(response, herepy.RoutingResponseV8)
+
+    @responses.activate
+    def test_route_v8_url_parameters_multiple(self):
+        responses.add(
+            responses.GET,
+            "https://router.hereapi.com/v8/routes",
+            "{}",
+            status=200,
+            match=[
+                responses.matchers.query_param_matcher(
+                    {"truck[height]": "15000", "truck[width]": "3000"}, strict_match=False
+                )
+            ],
+        )
+        self._api.route_v8(transport_mode=herepy.RoutingTransportMode.truck,
+            origin=[41.9798, -87.8801],
+            destination=[41.9043, -87.9216],
+            truck={"height": ["15000"], "width": ["3000"]}
+        )

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -29,3 +29,11 @@ class UtilsTest(unittest.TestCase):
             "https://geocoder.cit.api.here.com/6.2/geocode.json", data
         )
         self.assertTrue(url)
+
+    def test_build_url_sub_data(self):
+        data = {
+            "key1": "val",
+            "key2": {"sub_key": "sub_val", "sub_key2": "sub_val2"},
+        }
+        url = Utils.build_url("https://router.hereapi.com/v8/routes", data)
+        self.assertEqual(url, "https://router.hereapi.com/v8/routes?key1=val&key2%5Bsub_key%5D=sub_val&key2%5Bsub_key2%5D=sub_val2")


### PR DESCRIPTION
1. Improve `encode_parameters` method, so it processes dict parameters correctly. Here API expects multi-level dict to be expressed as `key[sub1]=val1&key[sub2]=val2`. The method supports only one level sub-dict, which as far as I know, should be enough.
2. Fix `route_v8` - `avoid`, `exclude` and `truck` parameters were not fully supported.

Fixes #83 