### PR TITLE
[FIX] Deprecate `truck` parameter in route_v8

### DIFF
--- a/herepy/routing_api.py
+++ b/herepy/routing_api.py
@@ -5,6 +5,7 @@ import json
 import os
 import sys
 from typing import Dict, List, Optional, Union
+from warnings import warn
 
 import requests
 
@@ -370,6 +371,7 @@ class RoutingApi(HEREApi):
         return_fields: List[RoutingApiReturnField] = [RoutingApiReturnField.polyline],
         span_fields: Optional[List[RoutingApiSpanField]] = None,
         truck: Optional[Dict[str, List[str]]] = None,
+        vehicle: Optional[Dict[str, List[str]]] = None,
         scooter: Optional[Dict[str, str]] = None,
         headers: Optional[dict] = None,
     ) -> Optional[RoutingResponseV8]:
@@ -417,7 +419,9 @@ class RoutingApi(HEREApi):
             For example, attributes,length will enable the fields attributes and length in the route response.
             This parameter also requires that the polyline option is set within the return parameter.
           truck (Optional[Dict[str, List[str]]]):
-            Comma-separated list of shipped hazardous goods in the vehicle.
+            Deprecated. Use `vehicle` parameter.
+          vehicle (Optional[Dict[str, List[str]]]):
+            Comma-separated list of vehicle-specific parameters.
             Sample use of parameter: `{"shippedHazardousGoods": [explosive, gas, flammable]}`
           scooter (Optional[Dict[str, str]]):
             Scooter specific parameters.
@@ -469,7 +473,15 @@ class RoutingApi(HEREApi):
         if span_fields:
             data["spans"] = ",".join([field.__str__() for field in span_fields])
         if truck:
-            data["truck"] = {key: ",".join(vals) for key, vals in truck.items()}
+            warn(
+                "'truck' parameter is deprecated in Routing API. Use 'vehicle' parameter instead.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            if vehicle is None:
+                vehicle = truck
+        if vehicle:
+            data["vehicle"] = {key: ",".join(vals) for key, vals in vehicle.items()}
         if scooter:
             data["scooter"] = scooter
 

--- a/tests/test_routing_api.py
+++ b/tests/test_routing_api.py
@@ -3,6 +3,7 @@
 import codecs
 import datetime
 import unittest
+import pytest
 
 import responses
 
@@ -1095,7 +1096,7 @@ class RoutingApiTest(unittest.TestCase):
             lang="tr-TR",
             return_fields=[herepy.RoutingApiReturnField.polyline],
             span_fields=[herepy.RoutingApiSpanField.walkAttributes],
-            truck={"shippedHazardousGoods": ["explosive", "gas"]},
+            vehicle={"shippedHazardousGoods": ["explosive", "gas"]},
             scooter={"allowHighway": "true"},
         )
         self.assertTrue(response)
@@ -1129,7 +1130,7 @@ class RoutingApiTest(unittest.TestCase):
                 lang="tr-TR",
                 return_fields=[herepy.RoutingApiReturnField.polyline],
                 span_fields=[herepy.RoutingApiSpanField.walkAttributes],
-                truck={"shippedHazardousGoods": ["explosive", "gas"]},
+                vehicle={"shippedHazardousGoods": ["explosive", "gas"]},
                 scooter={"allowHighway": "true"},
             )
 
@@ -1190,7 +1191,7 @@ class RoutingApiTest(unittest.TestCase):
                 lang="tr-TR",
                 return_fields=[herepy.RoutingApiReturnField.polyline],
                 span_fields=[herepy.RoutingApiSpanField.walkAttributes],
-                truck={"shippedHazardousGoods": ["explosive", "gas"]},
+                vehicle={"shippedHazardousGoods": ["explosive", "gas"]},
                 scooter={"allowHighway": "true"},
             )
 
@@ -1225,12 +1226,34 @@ class RoutingApiTest(unittest.TestCase):
             status=200,
             match=[
                 responses.matchers.query_param_matcher(
-                    {"truck[height]": "15000", "truck[width]": "3000"}, strict_match=False
+                    {"vehicle[height]": "15000", "vehicle[width]": "3000"}, strict_match=False
                 )
             ],
         )
         self._api.route_v8(transport_mode=herepy.RoutingTransportMode.truck,
             origin=[41.9798, -87.8801],
             destination=[41.9043, -87.9216],
-            truck={"height": ["15000"], "width": ["3000"]}
+            vehicle={"height": ["15000"], "width": ["3000"]}
+        )
+
+    @responses.activate
+    @pytest.mark.filterwarnings("ignore:'truck' parameter is deprecated")
+    def test_route_v8_truck_parameter_deprecated(self):
+        responses.add(
+            responses.GET,
+            "https://router.hereapi.com/v8/routes",
+            "{}",
+            status=200,
+            match=[
+                responses.matchers.query_param_matcher(
+                    {"vehicle[height]": "15000", "vehicle[width]": "3000"},
+                    strict_match=False,
+                )
+            ],
+        )
+        self._api.route_v8(
+            transport_mode=herepy.RoutingTransportMode.truck,
+            origin=[41.9798, -87.8801],
+            destination=[41.9043, -87.9216],
+            truck={"height": ["15000"], "width": ["3000"]},
         )


### PR DESCRIPTION
According to the documentation, `truck` attribute is deprecated in Routing requests if favour of `vehicle` attribute. This commit deprecates the `truck`attribute. 
It can be still used, however a warning will appear in the console and the request will be sent with `vehicle` attribute. Values accepted in both attributes are the same in the API.