### PR TITLE
[FIX] Support passing headers in `route_v8`

### DIFF
--- a/herepy/routing_api.py
+++ b/herepy/routing_api.py
@@ -49,12 +49,13 @@ class RoutingApi(HEREApi):
         response_cls,
         manipulation_key: str = None,
         keys_for_manipulation: List = None,
+        headers: Optional[Dict[str, str]] = None,
     ):
         url = Utils.build_url(base_url, extra_params=data)
         if manipulation_key and keys_for_manipulation:
             for k in keys_for_manipulation:
                 url = url.replace(k, manipulation_key)
-        response = requests.get(url, timeout=self._timeout)
+        response = requests.get(url, timeout=self._timeout, headers=headers)
         json_data = json.loads(response.content.decode("utf8"))
         if response.status_code == requests.codes.OK:
             return response_cls.new_from_jsondict(json_data)
@@ -480,6 +481,7 @@ class RoutingApi(HEREApi):
             RoutingResponseV8,
             manipulation_key="via",
             keys_for_manipulation=via_keys,
+            headers=headers
         )
         return response
 

--- a/tests/test_routing_api.py
+++ b/tests/test_routing_api.py
@@ -1234,3 +1234,20 @@ class RoutingApiTest(unittest.TestCase):
             destination=[41.9043, -87.9216],
             truck={"height": ["15000"], "width": ["3000"]}
         )
+
+    @responses.activate
+    def test_route_v8_headers_in_request(self):
+        resp = responses.add(
+            responses.GET,
+            "https://router.hereapi.com/v8/routes",
+            "{}",
+            status=200,
+        )
+        self._api.route_v8(
+            transport_mode=herepy.RoutingTransportMode.truck,
+            origin=[41.9798, -87.8801],
+            destination=[41.9043, -87.9216],
+            headers={"X-BIP": "BOP"},
+        )
+        original_request = resp.calls[0].request
+        self.assertEqual(original_request.headers.get("X-BIP"), "BOP")


### PR DESCRIPTION
In `route_v8` there is an option to pass custom headers to http request. However it was not actually passed. 